### PR TITLE
Derive Deserialize and Serialize for Arena, Node, and NodeId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,10 @@ categories = ["data-structures"]
 [badges]
 travis-ci = { repository = "saschagrunert/indextree", branch = "master" }
 appveyor = { repository = "saschagrunert/indextree", branch = "master", service = "github" }
+
+[features]
+deser = [ "serde", "serde_derive" ]
+
+[dependencies]
+serde = { version = "^1", optional = true }
+serde_derive = { version = "^1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,21 @@
 use std::{mem, fmt};
 use std::ops::{Index, IndexMut};
 
+#[cfg(feature = "deser")]
+extern crate serde;
+#[cfg(feature = "deser")]
+#[macro_use]
+extern crate serde_derive;
+
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
 /// A node identifier within a particular `Arena`
 pub struct NodeId {
     index: usize,
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
 /// A node within a particular `Arena`
 pub struct Node<T> {
     // Keep these private (with read-only accessors) so that we can keep them consistent.
@@ -55,6 +63,7 @@ impl<T> fmt::Display for Node<T> {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
 /// An `Arena` structure containing certain Nodes
 pub struct Arena<T> {
     nodes: Vec<Node<T>>,


### PR DESCRIPTION
This changeset adds a feature named `deser` which adds a dependency on `serde` and `serde_derive`.

I am using this change locally in a project for unit testing functions that produce `Arena`s so figured this may benefit upstream.

Of course the feature name can be changed easily.

If you don't want this please feel free to close this PR. :)