### PR TITLE
Implement Arena::{get, get_mut, find}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,21 @@ impl<T> Arena<T> {
     pub fn is_empty(&self) -> bool {
         self.count() == 0
     }
+
+    /// Get a reference to the node with the given id if in the arena, None otherwise.
+    pub fn get(&self, id: NodeId) -> Option<&Node<T>> {
+        self.nodes.get(id.index)
+    }
+
+    /// Get a mutable reference to the node with the given id if in the arena, None otherwise.
+    pub fn get_mut(&mut self, id: NodeId) -> Option<&mut Node<T>> {
+        self.nodes.get_mut(id.index)
+    }
+
+    /// Iterate over all nodes in the arena in storage-order.
+    pub fn iter(&self) -> std::slice::Iter<Node<T>> {
+        self.nodes.iter()
+    }
 }
 
 trait GetPairMut<T> {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -68,3 +68,37 @@ fn arenatree_success_detach() {
     b.detach(arena);
     assert_eq!(b.ancestors(arena).into_iter().count(), 1);
 }
+
+#[test]
+fn arenatree_get() {
+    let arena = &mut Arena::new();
+    let id = arena.new_node(1);
+    assert_eq!(arena.get(id).unwrap().data, 1);
+}
+
+#[test]
+fn arenatree_get_mut() {
+    let arena = &mut Arena::new();
+    let id = arena.new_node(1);
+    assert_eq!(arena.get_mut(id).unwrap().data, 1);
+}
+
+#[test]
+fn arenatree_iter() {
+    let arena = &mut Arena::new();
+    let a = arena.new_node(1);
+    let b = arena.new_node(2);
+    let c = arena.new_node(3);
+    let d = arena.new_node(4);
+    a.append(b, arena);
+    b.append(c, arena);
+    a.append(d, arena);
+
+    let node_refs = arena.iter().collect::<Vec<_>>();
+    assert_eq!(node_refs, vec![
+        &arena[a],
+        &arena[b],
+        &arena[c],
+        &arena[d],
+    ]);
+}


### PR DESCRIPTION
I'd prefer to implement `Iterator` but I haven't been able to figure out how to implement that yet.

---

The associated functions `get` and `get_mut` allow consuming code to retrieve a node without panicking if an invalid ID is given.

`find` is the part of `Iterator` that I am after, if you'd like that in a separate PR (or don't want it) just let me know.