### PR TITLE
Implement NodeId::new

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,11 @@ impl<T> Node<T> {
 }
 
 impl NodeId {
+    /// Create a `NodeId` used for attempting to get `Node`s references from an `Arena`.
+    pub fn new(index: usize) -> Self {
+        Self { index }
+    }
+
     /// Return an iterator of references to this node and its ancestors.
     ///
     /// Call `.next().unwrap()` once on the iterator to skip the node itself.


### PR DESCRIPTION
Without `NodeId::new` it is (AFAICT) impossible to use `index` and `index_mut` to get a node at a known index.

This will also make #8 easier to use (if it is accepted).