### PR TITLE
Make rayon optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_script:
   - cargo install cargo-kcov
 script:
   - export CARGO_TARGET_DIR=`pwd`/target
-  - travis-cargo build
-  - travis-cargo test
+  - travis-cargo build -- --features="par_iter"
+  - travis-cargo test -- --features="par_iter"
   - cargo doc --no-deps
 after_success:
   - if [[ "$TRAVIS_RUST_VERSION" == "stable" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo doc-upload; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,13 @@ appveyor = { repository = "saschagrunert/indextree", branch = "master", service 
 
 [features]
 deser = [ "serde", "serde_derive" ]
+par_iter = ["rayon"]
 
 [dependencies]
 serde = { version = "^1", optional = true }
 serde_derive = { version = "^1", optional = true }
-rayon = "^1"
+rayon = { version = "^1", optional = true }
+
+[[example]]
+name = "parallel_iteration"
+required-features = ["par_iter"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,5 +17,5 @@ install:
   - git submodule update --init --recursive
 build: false
 test_script:
-  - cargo test
+  - cargo test --features="par_iter"
   - cargo test --no-default-features

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,9 @@
 extern crate indextree;
+#[cfg(feature = "par_iter")]
 extern crate rayon;
 
 use indextree::Arena;
+#[cfg(feature = "par_iter")]
 use rayon::prelude::*;
 
 #[test]
@@ -85,6 +87,7 @@ fn arenatree_iter() {
     assert_eq!(node_refs, vec![&arena[a], &arena[b], &arena[c], &arena[d]]);
 }
 
+#[cfg(feature = "par_iter")]
 #[test]
 fn arenatree_par_iter() {
     let arena = &mut Arena::new();


### PR DESCRIPTION
Added a `par_iter` feature and removed `Sync` bounds where they are not needed.
I also formatted the code with rustfmt, but can remove the commit if you think this is unnecessary.

