### PR TITLE
Make `backtrace` feature of `failure` crate optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ derive-eq = []
 par_iter = ["rayon"]
 
 [dependencies]
-failure = "0.1.5"
+failure = { version = "0.1.5", features = ["derive"] }
 rayon = { version = "1.0.3", optional = true }
 serde = { version = "1.0.90", optional = true }
 serde_derive = { version = "1.0.90", optional = true }


### PR DESCRIPTION
User can enable the feature even if it is indirect dependency, but can
not disable if it is not explicitly disabled.
`indextree` itself does not depend on backtrace feature, so it should be
disabled and let users choose.