### PR TITLE
Implement `Default` trait for `Arena` type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ pub struct Arena<T> {
 impl<T> Arena<T> {
     /// Create a new empty `Arena`
     pub fn new() -> Arena<T> {
-        Arena { nodes: Vec::new() }
+        Self::default()
     }
 
     /// Create a new node from its associated data.
@@ -238,6 +238,14 @@ impl<T: Sync> Arena<T> {
     /// tested with the `is_removed()` method on the node.
     pub fn par_iter(&self) -> rayon::slice::Iter<Node<T>> {
         self.nodes.par_iter()
+    }
+}
+
+impl<T> Default for Arena<T> {
+    fn default() -> Self {
+        Self {
+            nodes: Vec::new(),
+        }
     }
 }
 


### PR DESCRIPTION
`Default` is implemented manually for `Arena`, but not using `#[derive(Default)]`.
This is because `#[derive(Default)]` adds unnecessary trait bound `T: Default` automatically (see https://github.com/rust-lang/rust/issues/26925).

Additionally, this change suppresses clippy lint to recommend deriving `Default` for simple `new()` method.
Clippy complains about that for previous code:
```
$ cargo clippy
warning: you should consider deriving a `Default` implementation for `arena::Arena<T>`
  --> src/arena.rs:41:5
   |
41 | /     pub fn new() -> Arena<T> {
42 | |         Arena { nodes: Vec::new() }
43 | |     }
   | |_____^
   |
   = note: #[warn(clippy::new_without_default)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
help: try this
   |
35 | #[derive(Default)]
   |

    Finished dev [unoptimized + debuginfo] target(s) in 0.27s
$
```