### PR TITLE
Fix node removal bug

### DIFF
--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -73,7 +73,7 @@ impl<'a, T> Iterator for Descendants<'a, T> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// Indicator if the node is at a start or endpoint of the tree
 pub enum NodeEdge<T> {
     /// Indicates that start of a node that has children. Yielded by

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -1,0 +1,388 @@
+use indextree::{
+    Arena,
+    NodeEdge::{End, Start},
+};
+
+#[test]
+fn toplevel_with_no_child() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    // arena
+    // `-- 1
+    assert!(n1.remove(&mut arena).is_ok());
+}
+
+#[test]
+fn toplevel_with_single_child() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n1_1 = arena.new_node("1_1");
+    n1.append(n1_1, &mut arena).unwrap();
+    // arena
+    // `-- 1 *
+    //     `-- 1_1
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[Start(n1), Start(n1_1), End(n1_1), End(n1)]
+    );
+    n1.remove(&mut arena).unwrap();
+    // arena
+    // `-- 1_1
+    assert!(arena[n1_1].parent().is_none());
+}
+
+#[test]
+fn toplevel_with_multiple_children() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n1_1 = arena.new_node("1_1");
+    n1.append(n1_1, &mut arena).unwrap();
+    let n1_2 = arena.new_node("1_2");
+    n1.append(n1_2, &mut arena).unwrap();
+    // arena
+    // `-- 1 *
+    //     |-- 1_1
+    //     `-- 1_2
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            End(n1_1),
+            Start(n1_2),
+            End(n1_2),
+            End(n1)
+        ]
+    );
+    n1.remove(&mut arena).unwrap();
+    // arena
+    // |-- 1_1
+    // `-- 1_2
+    assert!(arena[n1_1].parent().is_none());
+    assert!(arena[n1_2].parent().is_none());
+    assert_eq!(
+        n1_1.following_siblings(&arena).collect::<Vec<_>>(),
+        &[n1_1, n1_2]
+    );
+}
+
+#[test]
+fn single_child_with_no_children() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n1_1 = arena.new_node("1_1");
+    n1.append(n1_1, &mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     `-- 1_1 *
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[Start(n1), Start(n1_1), End(n1_1), End(n1),]
+    );
+    n1_1.remove(&mut arena).unwrap();
+    // arena
+    // `-- 1
+    assert!(arena[n1_1].parent().is_none());
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[Start(n1), End(n1),]
+    );
+}
+
+#[test]
+fn single_child_with_single_child() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n1_1 = arena.new_node("1_1");
+    n1.append(n1_1, &mut arena).unwrap();
+    let n1_1_1 = arena.new_node("1_1_1");
+    n1_1.append(n1_1_1, &mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     `-- 1_1 *
+    //         `-- 1_1_1
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            Start(n1_1_1),
+            End(n1_1_1),
+            End(n1_1),
+            End(n1),
+        ]
+    );
+    n1_1.remove(&mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     `-- 1_1_1
+    assert!(arena[n1_1].parent().is_none());
+    assert!(arena[n1_1].first_child().is_none());
+    assert_eq!(n1_1_1.ancestors(&arena).collect::<Vec<_>>(), &[n1_1_1, n1]);
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[Start(n1), Start(n1_1_1), End(n1_1_1), End(n1),]
+    );
+}
+
+#[test]
+fn first_child_with_no_children() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n1_1 = arena.new_node("1_1");
+    n1.append(n1_1, &mut arena).unwrap();
+    let n1_2 = arena.new_node("1_2");
+    n1.append(n1_2, &mut arena).unwrap();
+    let n1_3 = arena.new_node("1_3");
+    n1.append(n1_3, &mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     |-- 1_1 *
+    //     |-- 1_2
+    //     `-- 1_3
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            End(n1_1),
+            Start(n1_2),
+            End(n1_2),
+            Start(n1_3),
+            End(n1_3),
+            End(n1),
+        ]
+    );
+    n1_1.remove(&mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     |-- 1_2
+    //     `-- 1_3
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_2),
+            End(n1_2),
+            Start(n1_3),
+            End(n1_3),
+            End(n1),
+        ]
+    );
+}
+
+#[test]
+fn middle_child_with_no_children() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n1_1 = arena.new_node("1_1");
+    n1.append(n1_1, &mut arena).unwrap();
+    let n1_2 = arena.new_node("1_2");
+    n1.append(n1_2, &mut arena).unwrap();
+    let n1_3 = arena.new_node("1_3");
+    n1.append(n1_3, &mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     |-- 1_1
+    //     |-- 1_2 *
+    //     `-- 1_3
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            End(n1_1),
+            Start(n1_2),
+            End(n1_2),
+            Start(n1_3),
+            End(n1_3),
+            End(n1),
+        ]
+    );
+    n1_2.remove(&mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     |-- 1_1
+    //     `-- 1_3
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            End(n1_1),
+            Start(n1_3),
+            End(n1_3),
+            End(n1),
+        ]
+    );
+}
+
+#[test]
+fn last_child_with_no_children() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n1_1 = arena.new_node("1_1");
+    n1.append(n1_1, &mut arena).unwrap();
+    let n1_2 = arena.new_node("1_2");
+    n1.append(n1_2, &mut arena).unwrap();
+    let n1_3 = arena.new_node("1_3");
+    n1.append(n1_3, &mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     |-- 1_1
+    //     |-- 1_2
+    //     `-- 1_3 *
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            End(n1_1),
+            Start(n1_2),
+            End(n1_2),
+            Start(n1_3),
+            End(n1_3),
+            End(n1),
+        ]
+    );
+    n1_3.remove(&mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     |-- 1_1
+    //     `-- 1_2
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            End(n1_1),
+            Start(n1_2),
+            End(n1_2),
+            End(n1),
+        ]
+    );
+}
+
+#[test]
+fn middle_child_with_single_child() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n1_1 = arena.new_node("1_1");
+    n1.append(n1_1, &mut arena).unwrap();
+    let n1_2 = arena.new_node("1_2");
+    n1.append(n1_2, &mut arena).unwrap();
+    let n1_2_1 = arena.new_node("1_2_1");
+    n1_2.append(n1_2_1, &mut arena).unwrap();
+    let n1_3 = arena.new_node("1_3");
+    n1.append(n1_3, &mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     |-- 1_1
+    //     |-- 1_2 *
+    //     |   `-- 1_2_1
+    //     `-- 1_3
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            End(n1_1),
+            Start(n1_2),
+            Start(n1_2_1),
+            End(n1_2_1),
+            End(n1_2),
+            Start(n1_3),
+            End(n1_3),
+            End(n1),
+        ]
+    );
+    n1_2.remove(&mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     |-- 1_1
+    //     |-- 1_2_1
+    //     `-- 1_3
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            End(n1_1),
+            Start(n1_2_1),
+            End(n1_2_1),
+            Start(n1_3),
+            End(n1_3),
+            End(n1),
+        ]
+    );
+}
+
+#[test]
+fn middle_child_with_multiple_children() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n1_1 = arena.new_node("1_1");
+    n1.append(n1_1, &mut arena).unwrap();
+    let n1_2 = arena.new_node("1_2");
+    n1.append(n1_2, &mut arena).unwrap();
+    let n1_2_1 = arena.new_node("1_2_1");
+    n1_2.append(n1_2_1, &mut arena).unwrap();
+    let n1_2_2 = arena.new_node("1_2_2");
+    n1_2.append(n1_2_2, &mut arena).unwrap();
+    let n1_2_3 = arena.new_node("1_2_3");
+    n1_2.append(n1_2_3, &mut arena).unwrap();
+    let n1_3 = arena.new_node("1_3");
+    n1.append(n1_3, &mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     |-- 1_1
+    //     |-- 1_2 *
+    //     |   |-- 1_2_1
+    //     |   |-- 1_2_2
+    //     |   `-- 1_2_3
+    //     `-- 1_3
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            End(n1_1),
+            Start(n1_2),
+            Start(n1_2_1),
+            End(n1_2_1),
+            Start(n1_2_2),
+            End(n1_2_2),
+            Start(n1_2_3),
+            End(n1_2_3),
+            End(n1_2),
+            Start(n1_3),
+            End(n1_3),
+            End(n1),
+        ]
+    );
+    n1_2.remove(&mut arena).unwrap();
+    // arena
+    // `-- 1
+    //     |-- 1_1
+    //     |-- 1_2_1
+    //     |-- 1_2_2
+    //     |-- 1_2_3
+    //     `-- 1_3
+    assert_eq!(
+        n1.traverse(&arena).collect::<Vec<_>>(),
+        &[
+            Start(n1),
+            Start(n1_1),
+            End(n1_1),
+            Start(n1_2_1),
+            End(n1_2_1),
+            Start(n1_2_2),
+            End(n1_2_2),
+            Start(n1_2_3),
+            End(n1_2_3),
+            Start(n1_3),
+            End(n1_3),
+            End(n1),
+        ]
+    );
+}


### PR DESCRIPTION
* Add tests for `NodeId::remove()`
* Fix bug of `NodeId::remove()`
* Implement some std traits for `NodeEdge`
    + This is no-breaking change.

* * *

I'm currently working to add more assertions, examples, and tests (I'll make Pull Request later), and found that `NodeId::remove()` has a bug.
Tree becomes inconsistent after removing nodes.
(This can be checked by running tests at the commit <https://github.com/saschagrunert/indextree/pull/34/commits/0a7046b9ad9008d70fb1cb2c06552855b5eafec8>.)

I added tests and re-implement `NodeId::remove()`, and this version seems to work as expected.
(I'm adding many debug assertions to this code on another branch, and all of these assertions did not fail.)

To make tests easy and more complete, I added `#[derive(PartialEq, Eq, Hash)]` to `NodeEdge<T>`.
This is non-breaking change.

> Deriving more traits from the standard library using the `derive` attribute is not a breaking change.
>
> --- [Future proofing - Rust API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/future-proofing.html#data-structures-do-not-duplicate-derived-trait-bounds-c-struct-bounds)