### PR TITLE
Improve docs and tests

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -105,9 +105,7 @@ impl<T: Sync> Arena<T> {
 
 impl<T> Default for Arena<T> {
     fn default() -> Self {
-        Self {
-            nodes: Vec::new(),
-        }
+        Self { nodes: Vec::new() }
     }
 }
 
@@ -127,16 +125,11 @@ impl<T> IndexMut<NodeId> for Arena<T> {
 
 pub(crate) trait GetPairMut<T> {
     /// Get mutable references to two distinct nodes
-    fn get_tuple_mut(&mut self, a: usize, b: usize)
-        -> Option<(&mut T, &mut T)>;
+    fn get_tuple_mut(&mut self, a: usize, b: usize) -> Option<(&mut T, &mut T)>;
 }
 
 impl<T> GetPairMut<T> for Vec<T> {
-    fn get_tuple_mut(
-        &mut self,
-        a: usize,
-        b: usize,
-    ) -> Option<(&mut T, &mut T)> {
+    fn get_tuple_mut(&mut self, a: usize, b: usize) -> Option<(&mut T, &mut T)> {
         if a == b {
             return None;
         }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -48,6 +48,16 @@ impl<T> Arena<T> {
     /// # Panics
     ///
     /// Panics if the arena already has `usize::max_value()` nodes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    ///
+    /// assert_eq!(arena[foo].data, "foo");
+    /// ```
     pub fn new_node(&mut self, data: T) -> NodeId {
         let next_index1 = NonZeroUsize::new(self.nodes.len().wrapping_add(1))
             .expect("Too many nodes in the arena");
@@ -64,11 +74,40 @@ impl<T> Arena<T> {
     }
 
     /// Counts the number of nodes in arena and returns it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    /// let _bar = arena.new_node("bar");
+    /// assert_eq!(arena.count(), 2);
+    ///
+    /// let _ = foo.remove(&mut arena)?;
+    /// assert_eq!(arena.count(), 2);
+    /// # Ok::<(), failure::Error>(())
+    /// ```
     pub fn count(&self) -> usize {
         self.nodes.len()
     }
 
     /// Returns `true` if arena has no nodes, `false` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// assert!(arena.is_empty());
+    ///
+    /// let foo = arena.new_node("foo");
+    /// assert!(!arena.is_empty());
+    ///
+    /// foo.remove(&mut arena)?;
+    /// assert!(!arena.is_empty());
+    /// # Ok::<(), failure::Error>(())
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.count() == 0
     }
@@ -76,6 +115,32 @@ impl<T> Arena<T> {
     /// Returns a reference to the node with the given id if in the arena.
     ///
     /// Returns `None` if not available.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::{Arena, NodeId};
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    /// assert_eq!(arena.get(foo).map(|node| node.data), Some("foo"));
+    ///
+    /// let ghost = NodeId::new(42);
+    /// assert!(arena.get(ghost).is_none());
+    /// ```
+    ///
+    /// Note that this does not check whether the given node ID is created by
+    /// the arena.
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    /// assert_eq!(arena.get(foo).map(|node| node.data), Some("foo"));
+    ///
+    /// let mut another_arena = Arena::new();
+    /// let _ = another_arena.new_node("Another arena");
+    /// assert_eq!(another_arena.get(foo).map(|node| node.data), Some("Another arena"));
+    /// ```
     pub fn get(&self, id: NodeId) -> Option<&Node<T>> {
         self.nodes.get(id.index0())
     }
@@ -84,6 +149,21 @@ impl<T> Arena<T> {
     /// arena.
     ///
     /// Returns `None` if not available.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::{Arena, NodeId};
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    /// assert_eq!(arena.get(foo).map(|node| node.data), Some("foo"));
+    ///
+    /// let ghost = NodeId::new(42);
+    /// assert!(arena.get_mut(ghost).is_none());
+    ///
+    /// arena.get_mut(foo).expect("The `foo` node exists").data = "FOO!";
+    /// assert_eq!(arena.get(foo).map(|node| node.data), Some("FOO!"));
+    /// ```
     pub fn get_mut(&mut self, id: NodeId) -> Option<&mut Node<T>> {
         self.nodes.get_mut(id.index0())
     }
@@ -92,6 +172,34 @@ impl<T> Arena<T> {
     ///
     /// Note that this iterator returns also removed elements, which can be
     /// tested with the [`is_removed()`] method on the node.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let _foo = arena.new_node("foo");
+    /// let _bar = arena.new_node("bar");
+    ///
+    /// let mut iter = arena.iter();
+    /// assert_eq!(iter.next().map(|node| node.data), Some("foo"));
+    /// assert_eq!(iter.next().map(|node| node.data), Some("bar"));
+    /// assert_eq!(iter.next().map(|node| node.data), None);
+    /// ```
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let _foo = arena.new_node("foo");
+    /// let bar = arena.new_node("bar");
+    /// bar.remove(&mut arena)?;
+    ///
+    /// let mut iter = arena.iter();
+    /// assert_eq!(iter.next().map(|node| (node.data, node.is_removed())), Some(("foo", false)));
+    /// assert_eq!(iter.next().map(|node| (node.data, node.is_removed())), Some(("bar", true)));
+    /// assert_eq!(iter.next().map(|node| (node.data, node.is_removed())), None);
+    /// # Ok::<(), failure::Error>(())
+    /// ```
     ///
     /// [`is_removed()`]: struct.Node.html#method.is_removed
     pub fn iter(&self) -> Iter<Node<T>> {

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -30,18 +30,20 @@ use crate::{Node, NodeId};
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "derive-eq", derive(Eq))]
-/// An `Arena` structure containing certain Nodes
+/// An `Arena` structure containing certain [`Node`]s.
+///
+/// [`Node`]: struct.Node.html
 pub struct Arena<T> {
     pub(crate) nodes: Vec<Node<T>>,
 }
 
 impl<T> Arena<T> {
-    /// Create a new empty `Arena`
+    /// Creates a new empty `Arena`.
     pub fn new() -> Arena<T> {
         Self::default()
     }
 
-    /// Create a new node from its associated data.
+    /// Creates a new node from its associated data.
     ///
     /// # Panics
     ///
@@ -61,32 +63,37 @@ impl<T> Arena<T> {
         NodeId::from_non_zero_usize(next_index1)
     }
 
-    // Count nodes in arena.
+    /// Counts the number of nodes in arena and returns it.
     pub fn count(&self) -> usize {
         self.nodes.len()
     }
 
-    // Returns true if arena has no nodes, false otherwise
+    /// Returns `true` if arena has no nodes, `false` otherwise.
     pub fn is_empty(&self) -> bool {
         self.count() == 0
     }
 
-    /// Get a reference to the node with the given id if in the arena, None
-    /// otherwise.
+    /// Returns a reference to the node with the given id if in the arena.
+    ///
+    /// Returns `None` if not available.
     pub fn get(&self, id: NodeId) -> Option<&Node<T>> {
         self.nodes.get(id.index0())
     }
 
-    /// Get a mutable reference to the node with the given id if in the arena,
-    /// None otherwise.
+    /// Returns a mutable reference to the node with the given id if in the
+    /// arena.
+    ///
+    /// Returns `None` if not available.
     pub fn get_mut(&mut self, id: NodeId) -> Option<&mut Node<T>> {
         self.nodes.get_mut(id.index0())
     }
 
-    /// Iterate over all nodes in the arena in storage-order.
+    /// Returns an iterator of all nodes in the arena in storage-order.
     ///
-    /// Note that this iterator also contains removed elements, which can be
-    /// tested with the `is_removed()` method on the node.
+    /// Note that this iterator returns also removed elements, which can be
+    /// tested with the [`is_removed()`] method on the node.
+    ///
+    /// [`is_removed()`]: struct.Node.html#method.is_removed
     pub fn iter(&self) -> Iter<Node<T>> {
         self.nodes.iter()
     }
@@ -94,10 +101,12 @@ impl<T> Arena<T> {
 
 #[cfg(feature = "par_iter")]
 impl<T: Sync> Arena<T> {
-    /// Return an parallel iterator over the whole arena.
+    /// Returns an parallel iterator over the whole arena.
     ///
-    /// Note that this iterator also contains removed elements, which can be
-    /// tested with the `is_removed()` method on the node.
+    /// Note that this iterator returns also removed elements, which can be
+    /// tested with the [`is_removed()`] method on the node.
+    ///
+    /// [`is_removed()`]: struct.Node.html#method.is_removed
     pub fn par_iter(&self) -> rayon::slice::Iter<Node<T>> {
         self.nodes.par_iter()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 use failure::Fail;
 
 #[derive(Debug, Fail)]
-/// Possible node failures
+/// Possible node failures.
 pub enum NodeError {
     #[fail(display = "Can not append a node to itself")]
     AppendSelf,

--- a/src/id.rs
+++ b/src/id.rs
@@ -33,41 +33,6 @@ impl fmt::Display for NodeId {
     }
 }
 
-impl<T> Node<T> {
-    /// Return the ID of the parent node, unless this node is the root of the
-    /// tree.
-    pub fn parent(&self) -> Option<NodeId> {
-        self.parent
-    }
-
-    /// Return the ID of the first child of this node, unless it has no child.
-    pub fn first_child(&self) -> Option<NodeId> {
-        self.first_child
-    }
-
-    /// Return the ID of the last child of this node, unless it has no child.
-    pub fn last_child(&self) -> Option<NodeId> {
-        self.last_child
-    }
-
-    /// Return the ID of the previous sibling of this node, unless it is a
-    /// first child.
-    pub fn previous_sibling(&self) -> Option<NodeId> {
-        self.previous_sibling
-    }
-
-    /// Return the ID of the next sibling of this node, unless it is a
-    /// last child.
-    pub fn next_sibling(&self) -> Option<NodeId> {
-        self.next_sibling
-    }
-
-    /// Check if the node is marked as removed
-    pub fn is_removed(&self) -> bool {
-        self.removed
-    }
-}
-
 impl NodeId {
     /// Returns zero-based index.
     pub(crate) fn index0(self) -> usize {

--- a/src/id.rs
+++ b/src/id.rs
@@ -52,6 +52,20 @@ impl NodeId {
     ///
     /// Panics if the value is [`usize::max_value()`].
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::{Arena, NodeId};
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    /// let bar = arena.new_node("bar");
+    /// let baz = arena.new_node("baz");
+    ///
+    /// assert_eq!(NodeId::new(0), foo);
+    /// assert_eq!(NodeId::new(1), bar);
+    /// assert_eq!(NodeId::new(2), baz);
+    /// ```
+    ///
     /// [`usize::max_value()`]:
     /// https://doc.rust-lang.org/stable/std/primitive.usize.html#method.min_value
     pub fn new(index0: usize) -> Self {
@@ -61,6 +75,22 @@ impl NodeId {
     }
 
     /// Creates a new `NodeId` from the given one-based index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::num::NonZeroUsize;
+    /// # use indextree::{Arena, NodeId};
+    /// let mut arena = Arena::new();
+    /// let _foo = arena.new_node("foo");
+    /// let bar = arena.new_node("bar");
+    /// let _baz = arena.new_node("baz");
+    ///
+    /// let second_id = NonZeroUsize::new(2)
+    ///     .expect("Should success with non-zero integer");
+    /// let second = NodeId::from_non_zero_usize(second_id);
+    /// assert_eq!(second, bar);
+    /// ```
     pub fn from_non_zero_usize(index1: NonZeroUsize) -> Self {
         NodeId { index1 }
     }
@@ -69,6 +99,38 @@ impl NodeId {
     ///
     /// Use [`.skip(1)`][`skip`] or call `.next()` once on the iterator to skip
     /// the node itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_1_1 = arena.new_node("1_1_1");
+    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # let n1_1_1_1 = arena.new_node("1_1_1_1");
+    /// # n1_1_1.append(n1_1_1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |   `-- 1_1_1
+    /// //     |       `-- 1_1_1_1
+    /// //     _-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1_1_1.ancestors(&arena);
+    /// assert_eq!(iter.next(), Some(n1_1_1));
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), Some(n1));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
     pub fn ancestors<T>(self, arena: &Arena<T>) -> Ancestors<T> {
@@ -84,6 +146,34 @@ impl NodeId {
     /// Use [`.skip(1)`][`skip`] or call `.next()` once on the iterator to skip
     /// the node itself.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_1_1 = arena.new_node("1_1_1");
+    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |   `-- 1_1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1_2.preceding_siblings(&arena);
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
     pub fn preceding_siblings<T>(self, arena: &Arena<T>) -> PrecedingSiblings<T> {
         PrecedingSiblings {
@@ -97,6 +187,35 @@ impl NodeId {
     ///
     /// Use [`.skip(1)`][`skip`] or call `.next()` once on the iterator to skip
     /// the node itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_1_1 = arena.new_node("1_1_1");
+    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |   `-- 1_1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1_2.following_siblings(&arena);
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
     pub fn following_siblings<T>(self, arena: &Arena<T>) -> FollowingSiblings<T> {
         FollowingSiblings {
@@ -106,6 +225,35 @@ impl NodeId {
     }
 
     /// Returns an iterator of references to this node’s children.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_1_1 = arena.new_node("1_1_1");
+    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |   `-- 1_1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1.children(&arena);
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     pub fn children<T>(self, arena: &Arena<T>) -> Children<T> {
         Children {
             arena,
@@ -115,6 +263,35 @@ impl NodeId {
 
     /// Returns an iterator of references to this node’s children, in reverse
     /// order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_1_1 = arena.new_node("1_1_1");
+    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |   `-- 1_1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1.reverse_children(&arena);
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     pub fn reverse_children<T>(self, arena: &Arena<T>) -> ReverseChildren<T> {
         ReverseChildren {
             arena,
@@ -128,6 +305,42 @@ impl NodeId {
     /// Parent nodes appear before the descendants.
     /// Use [`.skip(1)`][`skip`] or call `.next()` once on the iterator to skip
     /// the node itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_1_1 = arena.new_node("1_1_1");
+    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # let n1_1_1_1 = arena.new_node("1_1_1_1");
+    /// # n1_1_1.append(n1_1_1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |   `-- 1_1_1
+    /// //     |       `-- 1_1_1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1.descendants(&arena);
+    /// assert_eq!(iter.next(), Some(n1));
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), Some(n1_1_1));
+    /// assert_eq!(iter.next(), Some(n1_1_1_1));
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
     pub fn descendants<T>(self, arena: &Arena<T>) -> Descendants<T> {
         Descendants(self.traverse(arena))
@@ -135,6 +348,42 @@ impl NodeId {
 
     /// Returns an iterator of references to this node and its descendants, in
     /// tree order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::{Arena, NodeEdge};
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_1_1 = arena.new_node("1_1_1");
+    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |   `-- 1_1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1.traverse(&arena);
+    /// assert_eq!(iter.next(), Some(NodeEdge::Start(n1)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::Start(n1_1)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::Start(n1_1_1)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::End(n1_1_1)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::End(n1_1)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::Start(n1_2)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::End(n1_2)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::Start(n1_3)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::End(n1_3)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::End(n1)));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     pub fn traverse<T>(self, arena: &Arena<T>) -> Traverse<T> {
         Traverse {
             arena,
@@ -145,6 +394,68 @@ impl NodeId {
 
     /// Returns an iterator of references to this node and its descendants, in
     /// reverse tree order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::{Arena, NodeEdge};
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_1_1 = arena.new_node("1_1_1");
+    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |   `-- 1_1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1.reverse_traverse(&arena);
+    /// assert_eq!(iter.next(), Some(NodeEdge::End(n1)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::End(n1_3)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::Start(n1_3)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::End(n1_2)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::Start(n1_2)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::End(n1_1)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::End(n1_1_1)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::Start(n1_1_1)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::Start(n1_1)));
+    /// assert_eq!(iter.next(), Some(NodeEdge::Start(n1)));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    ///
+    /// ```
+    /// # use indextree::{Arena, NodeEdge};
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_1_1 = arena.new_node("1_1_1");
+    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// # // arena
+    /// # // `-- 1
+    /// # //     |-- 1_1
+    /// # //     |   `-- 1_1_1
+    /// # //     |-- 1_2
+    /// # //     `-- 1_3
+    /// #
+    /// let traverse = n1.traverse(&arena).collect::<Vec<_>>();
+    /// let mut reverse = n1.reverse_traverse(&arena).collect::<Vec<_>>();
+    /// reverse.reverse();
+    /// assert_eq!(traverse, reverse);
+    /// ```
     pub fn reverse_traverse<T>(self, arena: &Arena<T>) -> ReverseTraverse<T> {
         ReverseTraverse {
             arena,
@@ -154,6 +465,51 @@ impl NodeId {
     }
 
     /// Detaches a node from its parent and siblings. Children are not affected.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::{Arena, NodeEdge};
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_1_1 = arena.new_node("1_1_1");
+    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// // arena
+    /// // `-- (implicit)
+    /// //     `-- 1
+    /// //         |-- 1_1
+    /// //         |   `-- 1_1_1
+    /// //         |-- 1_2 *
+    /// //         `-- 1_3
+    ///
+    /// n1_2.detach(&mut arena);
+    /// // arena
+    /// // |-- (implicit)
+    /// // |   `-- 1
+    /// // |       |-- 1_1
+    /// // |       |   `-- 1_1_1
+    /// // |       `-- 1_3
+    /// // `-- (implicit)
+    /// //     `-- 1_2
+    ///
+    /// assert!(arena[n1_2].parent().is_none());
+    /// assert!(arena[n1_2].previous_sibling().is_none());
+    /// assert!(arena[n1_2].next_sibling().is_none());
+    ///
+    /// let mut iter = n1.descendants(&arena);
+    /// assert_eq!(iter.next(), Some(n1));
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), Some(n1_1_1));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     pub fn detach<T>(self, arena: &mut Arena<T>) {
         let (parent, previous_sibling, next_sibling) = {
             let node = &mut arena[self];
@@ -182,6 +538,33 @@ impl NodeId {
     /// # Failures
     ///
     /// Returns an error if the given new child is `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = arena.new_node("1_1");
+    /// n1.append(n1_1, &mut arena);
+    /// let n1_2 = arena.new_node("1_2");
+    /// n1.append(n1_2, &mut arena);
+    /// let n1_3 = arena.new_node("1_3");
+    /// n1.append(n1_3, &mut arena);
+    ///
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1.descendants(&arena);
+    /// assert_eq!(iter.next(), Some(n1));
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     pub fn append<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
         new_child.detach(arena);
         let last_child_opt;
@@ -219,6 +602,33 @@ impl NodeId {
     /// # Failures
     ///
     /// Returns an error if the given new child is `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = arena.new_node("1_1");
+    /// n1.prepend(n1_1, &mut arena);
+    /// let n1_2 = arena.new_node("1_2");
+    /// n1.prepend(n1_2, &mut arena);
+    /// let n1_3 = arena.new_node("1_3");
+    /// n1.prepend(n1_3, &mut arena);
+    ///
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_3
+    /// //     |-- 1_2
+    /// //     `-- 1_1
+    ///
+    /// let mut iter = n1.descendants(&arena);
+    /// assert_eq!(iter.next(), Some(n1));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     pub fn prepend<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
         new_child.detach(arena);
         let first_child_opt;
@@ -256,6 +666,39 @@ impl NodeId {
     /// # Failures
     ///
     /// Returns an error if the given new sibling is `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = arena.new_node("1_1");
+    /// n1.append(n1_1, &mut arena);
+    /// let n1_2 = arena.new_node("1_2");
+    /// n1.append(n1_2, &mut arena);
+    ///
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     `-- 1_2
+    ///
+    /// let n1_3 = arena.new_node("1_3");
+    /// n1_1.insert_after(n1_3, &mut arena);
+    ///
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_3
+    /// //     `-- 1_2
+    ///
+    /// let mut iter = n1.descendants(&arena);
+    /// assert_eq!(iter.next(), Some(n1));
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     pub fn insert_after<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
         new_sibling.detach(arena);
         let next_sibling_opt;
@@ -299,6 +742,39 @@ impl NodeId {
     /// # Failures
     ///
     /// Returns an error if the given new sibling is `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = arena.new_node("1_1");
+    /// n1.append(n1_1, &mut arena);
+    /// let n1_2 = arena.new_node("1_2");
+    /// n1.append(n1_2, &mut arena);
+    ///
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     `-- 1_2
+    ///
+    /// let n1_3 = arena.new_node("1_3");
+    /// n1_2.insert_before(n1_3, &mut arena);
+    ///
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_3
+    /// //     `-- 1_2
+    ///
+    /// let mut iter = n1.descendants(&arena);
+    /// assert_eq!(iter.next(), Some(n1));
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     pub fn insert_before<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
         new_sibling.detach(arena);
         let previous_sibling_opt;
@@ -350,6 +826,43 @@ impl NodeId {
     /// plain iterator and contains removed elements too.
     ///
     /// To check if the node is removed or not, use [`Node::is_removed()`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_2_1 = arena.new_node("1_2_1");
+    /// # n1_2.append(n1_2_1, &mut arena);
+    /// # let n1_2_2 = arena.new_node("1_2_2");
+    /// # n1_2.append(n1_2_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// #
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_2
+    /// //     |   |-- 1_2_1
+    /// //     |   `-- 1_2_2
+    /// //     `-- 1_3
+    ///
+    /// n1_2.remove(&mut arena)?;
+    ///
+    /// let mut iter = n1.descendants(&arena);
+    /// assert_eq!(iter.next(), Some(n1));
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), Some(n1_2_1));
+    /// assert_eq!(iter.next(), Some(n1_2_2));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), None);
+    /// # Ok::<(), failure::Error>(())
+    /// ```
     ///
     /// [`Node::is_removed()`]: struct.Node.html#method.is_removed
     pub fn remove<T>(self, arena: &mut Arena<T>) -> Fallible<()> {

--- a/src/id.rs
+++ b/src/id.rs
@@ -4,10 +4,7 @@
 use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))]
-use core::{
-    fmt, mem,
-    num::NonZeroUsize,
-};
+use core::{fmt, mem, num::NonZeroUsize};
 
 use failure::{bail, Fallible};
 
@@ -15,15 +12,11 @@ use failure::{bail, Fallible};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
-use std::{
-    fmt, mem,
-    num::NonZeroUsize,
-};
+use std::{fmt, mem, num::NonZeroUsize};
 
 use crate::{
-    Ancestors, Arena, Children, Descendants, FollowingSiblings, GetPairMut,
-    Node, NodeEdge, NodeError, PrecedingSiblings, ReverseChildren,
-    ReverseTraverse, Traverse,
+    Ancestors, Arena, Children, Descendants, FollowingSiblings, GetPairMut, Node, NodeEdge,
+    NodeError, PrecedingSiblings, ReverseChildren, ReverseTraverse, Traverse,
 };
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Debug, Hash)]
@@ -116,10 +109,7 @@ impl NodeId {
     /// it.
     ///
     /// Call `.next().unwrap()` once on the iterator to skip the node itself.
-    pub fn preceding_siblings<T>(
-        self,
-        arena: &Arena<T>,
-    ) -> PrecedingSiblings<T> {
+    pub fn preceding_siblings<T>(self, arena: &Arena<T>) -> PrecedingSiblings<T> {
         PrecedingSiblings {
             arena,
             node: Some(self),
@@ -129,10 +119,7 @@ impl NodeId {
     /// Return an iterator of references to this node and the siblings after it.
     ///
     /// Call `.next().unwrap()` once on the iterator to skip the node itself.
-    pub fn following_siblings<T>(
-        self,
-        arena: &Arena<T>,
-    ) -> FollowingSiblings<T> {
+    pub fn following_siblings<T>(self, arena: &Arena<T>) -> FollowingSiblings<T> {
         FollowingSiblings {
             arena,
             node: Some(self),
@@ -210,11 +197,7 @@ impl NodeId {
     }
 
     /// Append a new child to this node, after existing children.
-    pub fn append<T>(
-        self,
-        new_child: NodeId,
-        arena: &mut Arena<T>,
-    ) -> Fallible<()> {
+    pub fn append<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
         new_child.detach(arena);
         let last_child_opt;
         {
@@ -222,8 +205,7 @@ impl NodeId {
                 arena.nodes.get_tuple_mut(self.index0(), new_child.index0())
             {
                 new_child_borrow.parent = Some(self);
-                last_child_opt =
-                    mem::replace(&mut self_borrow.last_child, Some(new_child));
+                last_child_opt = mem::replace(&mut self_borrow.last_child, Some(new_child));
                 if let Some(last_child) = last_child_opt {
                     new_child_borrow.previous_sibling = Some(last_child);
                 } else {
@@ -248,11 +230,7 @@ impl NodeId {
     }
 
     /// Prepend a new child to this node, before existing children.
-    pub fn prepend<T>(
-        self,
-        new_child: NodeId,
-        arena: &mut Arena<T>,
-    ) -> Fallible<()> {
+    pub fn prepend<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
         new_child.detach(arena);
         let first_child_opt;
         {
@@ -260,8 +238,7 @@ impl NodeId {
                 arena.nodes.get_tuple_mut(self.index0(), new_child.index0())
             {
                 new_child_borrow.parent = Some(self);
-                first_child_opt =
-                    mem::replace(&mut self_borrow.first_child, Some(new_child));
+                first_child_opt = mem::replace(&mut self_borrow.first_child, Some(new_child));
                 if let Some(first_child) = first_child_opt {
                     new_child_borrow.next_sibling = Some(first_child);
                 } else {
@@ -286,11 +263,7 @@ impl NodeId {
     }
 
     /// Insert a new sibling after this node.
-    pub fn insert_after<T>(
-        self,
-        new_sibling: NodeId,
-        arena: &mut Arena<T>,
-    ) -> Fallible<()> {
+    pub fn insert_after<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
         new_sibling.detach(arena);
         let next_sibling_opt;
         let parent_opt;
@@ -302,10 +275,7 @@ impl NodeId {
                 parent_opt = self_borrow.parent;
                 new_sibling_borrow.parent = parent_opt;
                 new_sibling_borrow.previous_sibling = Some(self);
-                next_sibling_opt = mem::replace(
-                    &mut self_borrow.next_sibling,
-                    Some(new_sibling),
-                );
+                next_sibling_opt = mem::replace(&mut self_borrow.next_sibling, Some(new_sibling));
                 if let Some(next_sibling) = next_sibling_opt {
                     new_sibling_borrow.next_sibling = Some(next_sibling);
                 }
@@ -315,13 +285,15 @@ impl NodeId {
         }
         if let Some(next_sibling) = next_sibling_opt {
             assert_eq!(
-                arena[next_sibling].previous_sibling, Some(self),
-                    "The previous sibling of the next sibling must be the current node"
+                arena[next_sibling].previous_sibling,
+                Some(self),
+                "The previous sibling of the next sibling must be the current node"
             );
             arena[next_sibling].previous_sibling = Some(new_sibling);
         } else if let Some(parent) = parent_opt {
             assert_eq!(
-                arena[parent].last_child, Some(self),
+                arena[parent].last_child,
+                Some(self),
                 "The last child of the parent mush be the current node"
             );
             arena[parent].last_child = Some(new_sibling);
@@ -331,11 +303,7 @@ impl NodeId {
 
     /// Insert a new sibling before this node.
     /// success.
-    pub fn insert_before<T>(
-        self,
-        new_sibling: NodeId,
-        arena: &mut Arena<T>,
-    ) -> Fallible<()> {
+    pub fn insert_before<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
         new_sibling.detach(arena);
         let previous_sibling_opt;
         let parent_opt;
@@ -347,13 +315,10 @@ impl NodeId {
                 parent_opt = self_borrow.parent;
                 new_sibling_borrow.parent = parent_opt;
                 new_sibling_borrow.next_sibling = Some(self);
-                previous_sibling_opt = mem::replace(
-                    &mut self_borrow.previous_sibling,
-                    Some(new_sibling),
-                );
+                previous_sibling_opt =
+                    mem::replace(&mut self_borrow.previous_sibling, Some(new_sibling));
                 if let Some(previous_sibling) = previous_sibling_opt {
-                    new_sibling_borrow.previous_sibling =
-                        Some(previous_sibling);
+                    new_sibling_borrow.previous_sibling = Some(previous_sibling);
                 }
             } else {
                 bail!(NodeError::InsertBeforeSelf);
@@ -361,7 +326,8 @@ impl NodeId {
         }
         if let Some(previous_sibling) = previous_sibling_opt {
             assert_eq!(
-                arena[previous_sibling].next_sibling, Some(self),
+                arena[previous_sibling].next_sibling,
+                Some(self),
                 "The next sibling of the previous sibling must be the current node"
             );
             arena[previous_sibling].next_sibling = Some(new_sibling);
@@ -369,7 +335,8 @@ impl NodeId {
             // The current node is the first child because it has no previous
             // siblings.
             assert_eq!(
-                arena[parent].first_child, Some(self),
+                arena[parent].first_child,
+                Some(self),
                 "The first child of the parent must be the current node"
             );
             arena[parent].first_child = Some(new_sibling);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@ pub use crate::{
     id::NodeId,
     node::Node,
     traverse::{
-        Ancestors, Children, Descendants, FollowingSiblings, NodeEdge,
-        PrecedingSiblings, ReverseChildren, ReverseTraverse, Traverse,
+        Ancestors, Children, Descendants, FollowingSiblings, NodeEdge, PrecedingSiblings,
+        ReverseChildren, ReverseTraverse, Traverse,
     },
 };
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -29,6 +29,41 @@ pub struct Node<T> {
     pub data: T,
 }
 
+impl<T> Node<T> {
+    /// Return the ID of the parent node, unless this node is the root of the
+    /// tree.
+    pub fn parent(&self) -> Option<NodeId> {
+        self.parent
+    }
+
+    /// Return the ID of the first child of this node, unless it has no child.
+    pub fn first_child(&self) -> Option<NodeId> {
+        self.first_child
+    }
+
+    /// Return the ID of the last child of this node, unless it has no child.
+    pub fn last_child(&self) -> Option<NodeId> {
+        self.last_child
+    }
+
+    /// Return the ID of the previous sibling of this node, unless it is a
+    /// first child.
+    pub fn previous_sibling(&self) -> Option<NodeId> {
+        self.previous_sibling
+    }
+
+    /// Return the ID of the next sibling of this node, unless it is a
+    /// last child.
+    pub fn next_sibling(&self) -> Option<NodeId> {
+        self.next_sibling
+    }
+
+    /// Check if the node is marked as removed
+    pub fn is_removed(&self) -> bool {
+        self.removed
+    }
+}
+
 impl<T> fmt::Display for Node<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(parent) = self.parent {

--- a/src/node.rs
+++ b/src/node.rs
@@ -14,7 +14,7 @@ use crate::NodeId;
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "derive-eq", derive(Eq))]
-/// A node within a particular `Arena`
+/// A node within a particular `Arena`.
 pub struct Node<T> {
     // Keep these private (with read-only accessors) so that we can keep them
     // consistent. E.g. the parent of a node’s child is that node.
@@ -25,40 +25,40 @@ pub struct Node<T> {
     pub(crate) last_child: Option<NodeId>,
     pub(crate) removed: bool,
 
-    /// The actual data which will be stored within the tree
+    /// The actual data which will be stored within the tree.
     pub data: T,
 }
 
 impl<T> Node<T> {
-    /// Return the ID of the parent node, unless this node is the root of the
+    /// Returns the ID of the parent node, unless this node is the root of the
     /// tree.
     pub fn parent(&self) -> Option<NodeId> {
         self.parent
     }
 
-    /// Return the ID of the first child of this node, unless it has no child.
+    /// Returns the ID of the first child of this node, unless it has no child.
     pub fn first_child(&self) -> Option<NodeId> {
         self.first_child
     }
 
-    /// Return the ID of the last child of this node, unless it has no child.
+    /// Returns the ID of the last child of this node, unless it has no child.
     pub fn last_child(&self) -> Option<NodeId> {
         self.last_child
     }
 
-    /// Return the ID of the previous sibling of this node, unless it is a
+    /// Returns the ID of the previous sibling of this node, unless it is a
     /// first child.
     pub fn previous_sibling(&self) -> Option<NodeId> {
         self.previous_sibling
     }
 
-    /// Return the ID of the next sibling of this node, unless it is a
+    /// Returns the ID of the next sibling of this node, unless it is a
     /// last child.
     pub fn next_sibling(&self) -> Option<NodeId> {
         self.next_sibling
     }
 
-    /// Check if the node is marked as removed
+    /// Checks if the node is marked as removed.
     pub fn is_removed(&self) -> bool {
         self.removed
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -32,33 +32,234 @@ pub struct Node<T> {
 impl<T> Node<T> {
     /// Returns the ID of the parent node, unless this node is the root of the
     /// tree.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_1, &mut arena);
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    /// assert_eq!(arena[n1].parent(), None);
+    /// assert_eq!(arena[n1_1].parent(), Some(n1));
+    /// assert_eq!(arena[n1_2].parent(), Some(n1));
+    /// assert_eq!(arena[n1_3].parent(), Some(n1));
+    /// ```
     pub fn parent(&self) -> Option<NodeId> {
         self.parent
     }
 
     /// Returns the ID of the first child of this node, unless it has no child.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    /// assert_eq!(arena[n1].first_child(), Some(n1_1));
+    /// assert_eq!(arena[n1_1].first_child(), None);
+    /// assert_eq!(arena[n1_2].first_child(), None);
+    /// assert_eq!(arena[n1_3].first_child(), None);
+    /// ```
     pub fn first_child(&self) -> Option<NodeId> {
         self.first_child
     }
 
     /// Returns the ID of the last child of this node, unless it has no child.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    /// assert_eq!(arena[n1].last_child(), Some(n1_3));
+    /// assert_eq!(arena[n1_1].last_child(), None);
+    /// assert_eq!(arena[n1_2].last_child(), None);
+    /// assert_eq!(arena[n1_3].last_child(), None);
+    /// ```
     pub fn last_child(&self) -> Option<NodeId> {
         self.last_child
     }
 
     /// Returns the ID of the previous sibling of this node, unless it is a
     /// first child.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    /// assert_eq!(arena[n1].previous_sibling(), None);
+    /// assert_eq!(arena[n1_1].previous_sibling(), None);
+    /// assert_eq!(arena[n1_2].previous_sibling(), Some(n1_1));
+    /// assert_eq!(arena[n1_3].previous_sibling(), Some(n1_2));
+    /// ```
+    ///
+    /// Note that newly created nodes are independent toplevel nodes, and they
+    /// are not siblings by default.
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n2 = arena.new_node("2");
+    /// // arena
+    /// // |-- (implicit)
+    /// // |   `-- 1
+    /// // `-- (implicit)
+    /// //     `-- 2
+    /// assert_eq!(arena[n1].previous_sibling(), None);
+    /// assert_eq!(arena[n2].previous_sibling(), None);
+    ///
+    /// n1.insert_after(n2, &mut arena)?;
+    /// // arena
+    /// // `-- (implicit)
+    /// //     |-- 1
+    /// //     `-- 2
+    /// assert_eq!(arena[n1].previous_sibling(), None);
+    /// assert_eq!(arena[n2].previous_sibling(), Some(n1));
+    /// # Ok::<(), failure::Error>(())
+    /// ```
     pub fn previous_sibling(&self) -> Option<NodeId> {
         self.previous_sibling
     }
 
     /// Returns the ID of the next sibling of this node, unless it is a
     /// last child.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    /// assert_eq!(arena[n1].next_sibling(), None);
+    /// assert_eq!(arena[n1_1].next_sibling(), Some(n1_2));
+    /// assert_eq!(arena[n1_2].next_sibling(), Some(n1_3));
+    /// assert_eq!(arena[n1_3].next_sibling(), None);
+    /// ```
+    ///
+    /// Note that newly created nodes are independent toplevel nodes, and they
+    /// are not siblings by default.
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n2 = arena.new_node("2");
+    /// // arena
+    /// // |-- (implicit)
+    /// // |   `-- 1
+    /// // `-- (implicit)
+    /// //     `-- 2
+    /// assert_eq!(arena[n1].next_sibling(), None);
+    /// assert_eq!(arena[n2].next_sibling(), None);
+    ///
+    /// n1.insert_after(n2, &mut arena)?;
+    /// // arena
+    /// // `-- (implicit)
+    /// //     |-- 1
+    /// //     `-- 2
+    /// assert_eq!(arena[n1].next_sibling(), Some(n2));
+    /// assert_eq!(arena[n2].next_sibling(), None);
+    /// # Ok::<(), failure::Error>(())
+    /// ```
     pub fn next_sibling(&self) -> Option<NodeId> {
         self.next_sibling
     }
 
     /// Checks if the node is marked as removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// # let n1_3 = arena.new_node("1_3");
+    /// # n1.append(n1_3, &mut arena);
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_2 *
+    /// //     `-- 1_3
+    /// assert_eq!(arena[n1_1].next_sibling(), Some(n1_2));
+    /// assert_eq!(arena[n1_2].parent(), Some(n1));
+    /// assert!(!arena[n1_2].is_removed());
+    /// assert_eq!(arena[n1_3].previous_sibling(), Some(n1_2));
+    ///
+    /// n1_2.remove(&mut arena)?;
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     `-- 1_3
+    /// assert_eq!(arena[n1_1].next_sibling(), Some(n1_3));
+    /// assert_eq!(arena[n1_2].parent(), None);
+    /// assert!(arena[n1_2].is_removed());
+    /// assert_eq!(arena[n1_3].previous_sibling(), Some(n1_1));
+    /// # Ok::<(), failure::Error>(())
+    /// ```
     pub fn is_removed(&self) -> bool {
         self.removed
     }

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -76,14 +76,16 @@ impl<'a, T> Iterator for Descendants<'a, T> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// Indicator if the node is at a start or endpoint of the tree
 pub enum NodeEdge<T> {
-    /// Indicates that start of a node that has children. Yielded by
-    /// `Traverse::next` before the node’s descendants. In HTML or XML, this
-    /// corresponds to an opening tag like `<div>`
+    /// Indicates that start of a node that has children.
+    ///
+    /// Yielded by `Traverse::next()` before the node’s descendants. In HTML or
+    /// XML, this corresponds to an opening tag like `<div>`.
     Start(T),
 
-    /// Indicates that end of a node that has children. Yielded by
-    /// `Traverse::next` after the node’s descendants. In HTML or XML, this
-    /// corresponds to a closing tag like `</div>`
+    /// Indicates that end of a node that has children.
+    ///
+    /// Yielded by `Traverse::next()` after the node’s descendants. In HTML or
+    /// XML, this corresponds to a closing tag like `</div>`
     End(T),
 }
 

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -102,8 +102,7 @@ impl<'a, T> Iterator for Traverse<'a, T> {
         match self.next.take() {
             Some(item) => {
                 self.next = match item {
-                    NodeEdge::Start(node) => match self.arena[node].first_child
-                    {
+                    NodeEdge::Start(node) => match self.arena[node].first_child {
                         Some(first_child) => Some(NodeEdge::Start(first_child)),
                         None => Some(NodeEdge::End(node)),
                     },
@@ -112,14 +111,10 @@ impl<'a, T> Iterator for Traverse<'a, T> {
                             None
                         } else {
                             match self.arena[node].next_sibling {
-                                Some(next_sibling) => {
-                                    Some(NodeEdge::Start(next_sibling))
-                                }
+                                Some(next_sibling) => Some(NodeEdge::Start(next_sibling)),
                                 None => {
                                     match self.arena[node].parent {
-                                        Some(parent) => {
-                                            Some(NodeEdge::End(parent))
-                                        }
+                                        Some(parent) => Some(NodeEdge::End(parent)),
 
                                         // `node.parent()` here can only be
                                         // `None` if the tree has been modified
@@ -164,14 +159,10 @@ impl<'a, T> Iterator for ReverseTraverse<'a, T> {
                             None
                         } else {
                             match self.arena[node].previous_sibling {
-                                Some(previous_sibling) => {
-                                    Some(NodeEdge::End(previous_sibling))
-                                }
+                                Some(previous_sibling) => Some(NodeEdge::End(previous_sibling)),
                                 None => {
                                     match self.arena[node].parent {
-                                        Some(parent) => {
-                                            Some(NodeEdge::Start(parent))
-                                        }
+                                        Some(parent) => Some(NodeEdge::Start(parent)),
 
                                         // `node.parent()` here can only be
                                         // `None` if the tree has been modified
@@ -191,4 +182,3 @@ impl<'a, T> Iterator for ReverseTraverse<'a, T> {
         }
     }
 }
-

--- a/tests/insert-error.rs
+++ b/tests/insert-error.rs
@@ -1,0 +1,31 @@
+//! Insertion errors.
+
+use indextree::Arena;
+
+#[test]
+fn append_self() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    assert!(n1.append(n1, &mut arena).is_err());
+}
+
+#[test]
+fn prepend_self() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    assert!(n1.prepend(n1, &mut arena).is_err());
+}
+
+#[test]
+fn insert_after_self() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    assert!(n1.insert_after(n1, &mut arena).is_err());
+}
+
+#[test]
+fn insert_before_self() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    assert!(n1.insert_before(n1, &mut arena).is_err());
+}


### PR DESCRIPTION
* Applied `rustfmt` formatter.
* Improved documentation.
    + Use [RFC 505](https://rust-lang.github.io/rfcs/0505-api-comment-conventions.html) convention (similar to std docs).
    + Use more links.
    + Add "examples" sections and "failures" sections to many methods.
* Add more tests.
    + Add tests for insertion failures.
    + Code examples in documentation also works as tests.
* Move impls to appropriate module (overlooked in #33).

This does not change any interfaces or behavior.