### PR TITLE
Refactoring

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -5,7 +5,6 @@ use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))]
 use core::{
-    cmp::max,
     num::NonZeroUsize,
     ops::{Index, IndexMut},
     slice::Iter,
@@ -19,7 +18,6 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use std::{
-    cmp::max,
     num::NonZeroUsize,
     ops::{Index, IndexMut},
     slice::Iter,
@@ -34,7 +32,7 @@ use crate::{Node, NodeId};
 ///
 /// [`Node`]: struct.Node.html
 pub struct Arena<T> {
-    pub(crate) nodes: Vec<Node<T>>,
+    nodes: Vec<Node<T>>,
 }
 
 impl<T> Arena<T> {
@@ -237,24 +235,5 @@ impl<T> Index<NodeId> for Arena<T> {
 impl<T> IndexMut<NodeId> for Arena<T> {
     fn index_mut(&mut self, node: NodeId) -> &mut Node<T> {
         &mut self.nodes[node.index0()]
-    }
-}
-
-pub(crate) trait GetPairMut<T> {
-    /// Get mutable references to two distinct nodes
-    fn get_tuple_mut(&mut self, a: usize, b: usize) -> Option<(&mut T, &mut T)>;
-}
-
-impl<T> GetPairMut<T> for Vec<T> {
-    fn get_tuple_mut(&mut self, a: usize, b: usize) -> Option<(&mut T, &mut T)> {
-        if a == b {
-            return None;
-        }
-        let (xs, ys) = self.split_at_mut(max(a, b));
-        if a < b {
-            Some((&mut xs[a], &mut ys[0]))
-        } else {
-            Some((&mut ys[0], &mut xs[b]))
-        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,12 @@
 //! Errors.
 
+#[cfg(not(feature = "std"))]
+use core::fmt;
+
 use failure::Fail;
+
+#[cfg(feature = "std")]
+use std::{error, fmt};
 
 #[derive(Debug, Fail)]
 /// Possible node failures.
@@ -61,3 +67,26 @@ pub enum NodeError {
     #[fail(display = "Last child is not set")]
     LastChildNotSet,
 }
+
+/// An error type that represents the given structure or argument is
+/// inconsistent or invalid.
+// Intended for internal use.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ConsistencyError {
+    /// Specified a node as its parent.
+    ParentChildLoop,
+    /// Specified a node as its sibling.
+    SiblingsLoop,
+}
+
+impl fmt::Display for ConsistencyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConsistencyError::ParentChildLoop => f.write_str("Specified a node as its parent"),
+            ConsistencyError::SiblingsLoop => f.write_str("Specified a node as its sibling"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl error::Error for ConsistencyError {}

--- a/src/id.rs
+++ b/src/id.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, mem, num::NonZeroUsize};
 
 use crate::{
-    Ancestors, Arena, Children, Descendants, FollowingSiblings, GetPairMut, NodeEdge, NodeError,
+    Ancestors, Arena, Children, Descendants, FollowingSiblings, GetPairMut, NodeError,
     PrecedingSiblings, ReverseChildren, ReverseTraverse, Traverse,
 };
 
@@ -134,10 +134,7 @@ impl NodeId {
     ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
     pub fn ancestors<T>(self, arena: &Arena<T>) -> Ancestors<T> {
-        Ancestors {
-            arena,
-            node: Some(self),
-        }
+        Ancestors::new(arena, self)
     }
 
     /// Returns an iterator of references to this node and the siblings before
@@ -176,10 +173,7 @@ impl NodeId {
     ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
     pub fn preceding_siblings<T>(self, arena: &Arena<T>) -> PrecedingSiblings<T> {
-        PrecedingSiblings {
-            arena,
-            node: Some(self),
-        }
+        PrecedingSiblings::new(arena, self)
     }
 
     /// Returns an iterator of references to this node and the siblings after
@@ -218,10 +212,7 @@ impl NodeId {
     ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
     pub fn following_siblings<T>(self, arena: &Arena<T>) -> FollowingSiblings<T> {
-        FollowingSiblings {
-            arena,
-            node: Some(self),
-        }
+        FollowingSiblings::new(arena, self)
     }
 
     /// Returns an iterator of references to this node’s children.
@@ -255,10 +246,7 @@ impl NodeId {
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn children<T>(self, arena: &Arena<T>) -> Children<T> {
-        Children {
-            arena,
-            node: arena[self].first_child,
-        }
+        Children::new(arena, self)
     }
 
     /// Returns an iterator of references to this node’s children, in reverse
@@ -293,10 +281,7 @@ impl NodeId {
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn reverse_children<T>(self, arena: &Arena<T>) -> ReverseChildren<T> {
-        ReverseChildren {
-            arena,
-            node: arena[self].last_child,
-        }
+        ReverseChildren::new(arena, self)
     }
 
     /// Returns an iterator of references to this node and its descendants, in
@@ -343,7 +328,7 @@ impl NodeId {
     ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
     pub fn descendants<T>(self, arena: &Arena<T>) -> Descendants<T> {
-        Descendants(self.traverse(arena))
+        Descendants::new(arena, self)
     }
 
     /// Returns an iterator of references to this node and its descendants, in
@@ -385,11 +370,7 @@ impl NodeId {
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn traverse<T>(self, arena: &Arena<T>) -> Traverse<T> {
-        Traverse {
-            arena,
-            root: self,
-            next: Some(NodeEdge::Start(self)),
-        }
+        Traverse::new(arena, self)
     }
 
     /// Returns an iterator of references to this node and its descendants, in
@@ -457,11 +438,7 @@ impl NodeId {
     /// assert_eq!(traverse, reverse);
     /// ```
     pub fn reverse_traverse<T>(self, arena: &Arena<T>) -> ReverseTraverse<T> {
-        ReverseTraverse {
-            arena,
-            root: self,
-            next: Some(NodeEdge::End(self)),
-        }
+        ReverseTraverse::new(arena, self)
     }
 
     /// Detaches a node from its parent and siblings. Children are not affected.

--- a/src/id.rs
+++ b/src/id.rs
@@ -493,6 +493,12 @@ impl NodeId {
         range
             .rewrite_parents(arena, None)
             .expect("Should never happen: `None` as parent is always valid");
+
+        // Ensure the node is surely detached.
+        debug_assert!(
+            arena[self].is_detached(),
+            "The node should be successfully detached"
+        );
     }
 
     /// Appends a new child to this node, after existing children.
@@ -772,6 +778,7 @@ impl NodeId {
                 .expect("Should never fail: neighbors and children must be consistent");
         }
         arena[self].removed = true;
+        debug_assert!(arena[self].is_detached());
 
         Ok(())
     }

--- a/src/id.rs
+++ b/src/id.rs
@@ -4,7 +4,7 @@
 use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))]
-use core::{fmt, mem, num::NonZeroUsize};
+use core::{fmt, num::NonZeroUsize};
 
 use failure::{bail, Fallible};
 
@@ -12,11 +12,12 @@ use failure::{bail, Fallible};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
-use std::{fmt, mem, num::NonZeroUsize};
+use std::{fmt, num::NonZeroUsize};
 
 use crate::{
-    Ancestors, Arena, Children, Descendants, FollowingSiblings, GetPairMut, NodeError,
-    PrecedingSiblings, ReverseChildren, ReverseTraverse, Traverse,
+    relations::insert_with_neighbors, siblings_range::SiblingsRange, Ancestors, Arena, Children,
+    Descendants, FollowingSiblings, NodeError, PrecedingSiblings, ReverseChildren, ReverseTraverse,
+    Traverse,
 };
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Debug, Hash)]
@@ -488,26 +489,10 @@ impl NodeId {
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn detach<T>(self, arena: &mut Arena<T>) {
-        let (parent, previous_sibling, next_sibling) = {
-            let node = &mut arena[self];
-            (
-                node.parent.take(),
-                node.previous_sibling.take(),
-                node.next_sibling.take(),
-            )
-        };
-
-        if let Some(next_sibling) = next_sibling {
-            arena[next_sibling].previous_sibling = previous_sibling;
-        } else if let Some(parent) = parent {
-            arena[parent].last_child = previous_sibling;
-        }
-
-        if let Some(previous_sibling) = previous_sibling {
-            arena[previous_sibling].next_sibling = next_sibling;
-        } else if let Some(parent) = parent {
-            arena[parent].first_child = next_sibling;
-        }
+        let range = SiblingsRange::new(self, self).detach_from_siblings(arena);
+        range
+            .rewrite_parents(arena, None)
+            .expect("Should never happen: `None` as parent is always valid");
     }
 
     /// Appends a new child to this node, after existing children.
@@ -543,34 +528,13 @@ impl NodeId {
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn append<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
+        if new_child == self {
+            bail!(NodeError::AppendSelf);
+        }
         new_child.detach(arena);
-        let last_child_opt;
-        {
-            if let Some((self_borrow, new_child_borrow)) =
-                arena.nodes.get_tuple_mut(self.index0(), new_child.index0())
-            {
-                new_child_borrow.parent = Some(self);
-                last_child_opt = mem::replace(&mut self_borrow.last_child, Some(new_child));
-                if let Some(last_child) = last_child_opt {
-                    new_child_borrow.previous_sibling = Some(last_child);
-                } else {
-                    assert!(
-                        self_borrow.first_child.is_none(),
-                        "`first_child` must be `None` if `last_child` was `None`"
-                    );
-                    self_borrow.first_child = Some(new_child);
-                }
-            } else {
-                bail!(NodeError::AppendSelf);
-            }
-        }
-        if let Some(last_child) = last_child_opt {
-            assert!(
-                arena[last_child].next_sibling.is_none(),
-                "The last child must not have next sibling"
-            );
-            arena[last_child].next_sibling = Some(new_child);
-        }
+        insert_with_neighbors(arena, new_child, Some(self), arena[self].last_child, None)
+            .expect("Should never fail: `new_child` is not `self`");
+
         Ok(())
     }
 
@@ -607,34 +571,12 @@ impl NodeId {
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn prepend<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
-        new_child.detach(arena);
-        let first_child_opt;
-        {
-            if let Some((self_borrow, new_child_borrow)) =
-                arena.nodes.get_tuple_mut(self.index0(), new_child.index0())
-            {
-                new_child_borrow.parent = Some(self);
-                first_child_opt = mem::replace(&mut self_borrow.first_child, Some(new_child));
-                if let Some(first_child) = first_child_opt {
-                    new_child_borrow.next_sibling = Some(first_child);
-                } else {
-                    assert!(
-                        self_borrow.last_child.is_none(),
-                        "`last_child` must be `None` if `first_child` was `None`"
-                    );
-                    self_borrow.last_child = Some(new_child);
-                }
-            } else {
-                bail!(NodeError::PrependSelf);
-            }
+        if new_child == self {
+            bail!(NodeError::PrependSelf);
         }
-        if let Some(first_child) = first_child_opt {
-            assert!(
-                arena[first_child].previous_sibling.is_none(),
-                "The last child must not have next sibling"
-            );
-            arena[first_child].previous_sibling = Some(new_child);
-        }
+        insert_with_neighbors(arena, new_child, Some(self), None, arena[self].first_child)
+            .expect("Should never fail: `new_child` is not `self`");
+
         Ok(())
     }
 
@@ -677,40 +619,17 @@ impl NodeId {
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn insert_after<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
+        if new_sibling == self {
+            bail!(NodeError::InsertAfterSelf);
+        }
         new_sibling.detach(arena);
-        let next_sibling_opt;
-        let parent_opt;
-        {
-            if let Some((self_borrow, new_sibling_borrow)) = arena
-                .nodes
-                .get_tuple_mut(self.index0(), new_sibling.index0())
-            {
-                parent_opt = self_borrow.parent;
-                new_sibling_borrow.parent = parent_opt;
-                new_sibling_borrow.previous_sibling = Some(self);
-                next_sibling_opt = mem::replace(&mut self_borrow.next_sibling, Some(new_sibling));
-                if let Some(next_sibling) = next_sibling_opt {
-                    new_sibling_borrow.next_sibling = Some(next_sibling);
-                }
-            } else {
-                bail!(NodeError::InsertAfterSelf);
-            }
-        }
-        if let Some(next_sibling) = next_sibling_opt {
-            assert_eq!(
-                arena[next_sibling].previous_sibling,
-                Some(self),
-                "The previous sibling of the next sibling must be the current node"
-            );
-            arena[next_sibling].previous_sibling = Some(new_sibling);
-        } else if let Some(parent) = parent_opt {
-            assert_eq!(
-                arena[parent].last_child,
-                Some(self),
-                "The last child of the parent mush be the current node"
-            );
-            arena[parent].last_child = Some(new_sibling);
-        }
+        let (next_sibling, parent) = {
+            let current = &arena[self];
+            (current.next_sibling, current.parent)
+        };
+        insert_with_neighbors(arena, new_sibling, parent, Some(self), next_sibling)
+            .expect("Should never fail: `new_sibling` is not `self`");
+
         Ok(())
     }
 
@@ -753,43 +672,17 @@ impl NodeId {
     /// assert_eq!(iter.next(), None);
     /// ```
     pub fn insert_before<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
+        if new_sibling == self {
+            bail!(NodeError::InsertBeforeSelf);
+        }
         new_sibling.detach(arena);
-        let previous_sibling_opt;
-        let parent_opt;
-        {
-            if let Some((self_borrow, new_sibling_borrow)) = arena
-                .nodes
-                .get_tuple_mut(self.index0(), new_sibling.index0())
-            {
-                parent_opt = self_borrow.parent;
-                new_sibling_borrow.parent = parent_opt;
-                new_sibling_borrow.next_sibling = Some(self);
-                previous_sibling_opt =
-                    mem::replace(&mut self_borrow.previous_sibling, Some(new_sibling));
-                if let Some(previous_sibling) = previous_sibling_opt {
-                    new_sibling_borrow.previous_sibling = Some(previous_sibling);
-                }
-            } else {
-                bail!(NodeError::InsertBeforeSelf);
-            }
-        }
-        if let Some(previous_sibling) = previous_sibling_opt {
-            assert_eq!(
-                arena[previous_sibling].next_sibling,
-                Some(self),
-                "The next sibling of the previous sibling must be the current node"
-            );
-            arena[previous_sibling].next_sibling = Some(new_sibling);
-        } else if let Some(parent) = parent_opt {
-            // The current node is the first child because it has no previous
-            // siblings.
-            assert_eq!(
-                arena[parent].first_child,
-                Some(self),
-                "The first child of the parent must be the current node"
-            );
-            arena[parent].first_child = Some(new_sibling);
-        }
+        let (previous_sibling, parent) = {
+            let current = &arena[self];
+            (current.previous_sibling, current.parent)
+        };
+        insert_with_neighbors(arena, new_sibling, parent, previous_sibling, Some(self))
+            .expect("Should never fail: `new_sibling` is not `self`");
+
         Ok(())
     }
 
@@ -843,56 +736,42 @@ impl NodeId {
     ///
     /// [`Node::is_removed()`]: struct.Node.html#method.is_removed
     pub fn remove<T>(self, arena: &mut Arena<T>) -> Fallible<()> {
-        // Retrieve needed values and detach this node
+        debug_assert_triangle_nodes!(
+            arena,
+            arena[self].parent,
+            arena[self].previous_sibling,
+            Some(self)
+        );
+        debug_assert_triangle_nodes!(
+            arena,
+            arena[self].parent,
+            Some(self),
+            arena[self].next_sibling
+        );
+        debug_assert_triangle_nodes!(arena, Some(self), None, arena[self].first_child);
+        debug_assert_triangle_nodes!(arena, Some(self), arena[self].last_child, None);
+
+        // Retrieve needed values.
         let (parent, previous_sibling, next_sibling, first_child, last_child) = {
-            let node = &mut arena[self];
+            let node = &arena[self];
             (
-                node.parent.take(),
-                node.previous_sibling.take(),
-                node.next_sibling.take(),
-                node.first_child.take(),
-                node.last_child.take(),
+                node.parent,
+                node.previous_sibling,
+                node.next_sibling,
+                node.first_child,
+                node.last_child,
             )
         };
-        // Note that no `is_detached()` assertion here because neighbor nodes
-        // are not yet updated consistently.
 
-        // Modify the parents of the childs
-        {
-            let mut child_opt = first_child;
-            while let Some(child_node) = child_opt.map(|id| &mut arena[id]) {
-                child_node.parent = parent;
-                child_opt = child_node.next_sibling;
-            }
+        assert_eq!(first_child.is_some(), last_child.is_some());
+        self.detach(arena);
+        if let (Some(first_child), Some(last_child)) = (first_child, last_child) {
+            let range = SiblingsRange::new(first_child, last_child).detach_from_siblings(arena);
+            range
+                .transplant(arena, parent, previous_sibling, next_sibling)
+                .expect("Should never fail: neighbors and children must be consistent");
         }
-
-        debug_assert_eq!(first_child.is_some(), last_child.is_some());
-        // `prev => ???` and `parent->first_child`
-        if let Some(previous_sibling) = previous_sibling {
-            arena[previous_sibling].next_sibling = first_child.or(next_sibling);
-        } else if let Some(parent) = parent {
-            arena[parent].first_child = first_child.or(next_sibling);
-        }
-        // `??? => first_child`
-        if let Some(first_child) = first_child {
-            arena[first_child].previous_sibling = previous_sibling;
-        }
-        // `last_child => ???`
-        if let Some(last_child) = last_child {
-            arena[last_child].next_sibling = next_sibling;
-        }
-        // `??? => next` and `parent->last_child`
-        if let Some(next_sibling) = next_sibling {
-            arena[next_sibling].previous_sibling = last_child.or(previous_sibling);
-        } else if let Some(parent) = parent {
-            arena[parent].last_child = last_child.or(previous_sibling);
-        }
-
-        // Cleanup the current node
-        {
-            let mut_self = &mut arena[self];
-            mut_self.removed = true;
-        }
+        arena[self].removed = true;
 
         Ok(())
     }

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,9 +1,6 @@
 //! Node ID.
 
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
-#[cfg(not(feature = "std"))]
 use core::{fmt, num::NonZeroUsize};
 
 use failure::{bail, Fallible};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,4 +44,5 @@ mod arena;
 mod error;
 mod id;
 mod node;
+pub(crate) mod relations;
 mod traverse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use crate::arena::GetPairMut;
 pub use crate::{
     arena::Arena,
     error::NodeError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,12 @@ pub use crate::{
     },
 };
 
+#[macro_use]
+pub(crate) mod relations;
+
 mod arena;
-mod error;
+pub(crate) mod error;
 mod id;
 mod node;
-pub(crate) mod relations;
+pub(crate) mod siblings_range;
 mod traverse;

--- a/src/node.rs
+++ b/src/node.rs
@@ -263,6 +263,11 @@ impl<T> Node<T> {
     pub fn is_removed(&self) -> bool {
         self.removed
     }
+
+    /// Checks if the node is detached.
+    pub(crate) fn is_detached(&self) -> bool {
+        self.parent.is_none() && self.previous_sibling.is_none() && self.next_sibling.is_none()
+    }
 }
 
 impl<T> fmt::Display for Node<T> {

--- a/src/relations.rs
+++ b/src/relations.rs
@@ -1,0 +1,102 @@
+//! Utilities related to nodes relations.
+
+use crate::{Arena, NodeId};
+
+/// Ensures the given parent, previous, and next nodes are consistent.
+///
+/// This assert is only enabled in debug build.
+macro_rules! debug_assert_triangle_nodes {
+    ($arena:expr, $parent:expr, $previous:expr, $next:expr $(,)?) => {{
+        if cfg!(debug_assertions) {
+            crate::relations::assert_triangle_nodes($arena, $parent, $previous, $next);
+        }
+    }};
+}
+
+/// Ensures the given parent, previous, and next nodes are consistent.
+///
+/// # Panics
+///
+/// Panics if the given nodes are inconsistent.
+pub(crate) fn assert_triangle_nodes<T>(
+    arena: &Arena<T>,
+    parent: Option<NodeId>,
+    previous: Option<NodeId>,
+    next: Option<NodeId>,
+) {
+    if let Some(previous_node) = previous.map(|id| &arena[id]) {
+        assert_eq!(
+            previous_node.parent, parent,
+            "`prev->parent` must equal to `parent`"
+        );
+        assert_eq!(
+            previous_node.next_sibling, next,
+            "`prev->next` must equal to `next`"
+        );
+    }
+    if let Some(next_node) = next.map(|id| &arena[id]) {
+        assert_eq!(
+            next_node.parent, parent,
+            "`next->parent` must equal to `parent`"
+        );
+        assert_eq!(
+            next_node.previous_sibling, previous,
+            "`next->prev` must equal to `prev`"
+        );
+    }
+}
+
+/// Connects the given adjacent neighbor nodes and update fields properly.
+///
+/// This connects the given three nodes (if `Some(_)`) and update fields to make
+/// them consistent.
+///
+/// ```text
+///    parent
+///     /  \
+///    /    \
+/// prev -> next
+/// ```
+pub(crate) fn connect_neighbors<T>(
+    arena: &mut Arena<T>,
+    parent: Option<NodeId>,
+    previous: Option<NodeId>,
+    next: Option<NodeId>,
+) {
+    if cfg!(debug_assertions) {
+        if let Some(parent_node) = parent.map(|id| &arena[id]) {
+            debug_assert_eq!(
+                parent_node.first_child.is_some(),
+                parent_node.last_child.is_some()
+            );
+        }
+    }
+
+    let (mut parent_first_child, mut parent_last_child) = parent
+        .map(|id| &arena[id])
+        .map_or((None, None), |node| (node.first_child, node.last_child));
+    if let Some(previous) = previous {
+        // `previous` ==> `next`
+        arena[previous].next_sibling = next;
+        parent_first_child = parent_first_child.or(Some(previous));
+    } else {
+        // `next` is the first child of the parent.
+        parent_first_child = next;
+    }
+    if let Some(next) = next {
+        // `previous` <== `next`
+        arena[next].previous_sibling = previous;
+        parent_last_child = parent_last_child.or(Some(next));
+    } else {
+        // `previous` is the last child of the parent.
+        parent_last_child = previous;
+    }
+
+    if let Some(parent_node) = parent.map(|id| &mut arena[id]) {
+        debug_assert_eq!(parent_first_child.is_some(), parent_last_child.is_some());
+        parent_node.first_child = parent_first_child;
+        parent_node.last_child = parent_last_child;
+    }
+
+    debug_assert_triangle_nodes!(arena, parent, previous, next);
+}

--- a/src/siblings_range.rs
+++ b/src/siblings_range.rs
@@ -1,0 +1,156 @@
+//! Sibling nodes range.
+
+use crate::{error::ConsistencyError, relations::connect_neighbors, Arena, NodeId};
+
+/// Siblings range.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SiblingsRange {
+    /// First node.
+    first: NodeId,
+    /// Last node.
+    last: NodeId,
+}
+
+impl SiblingsRange {
+    /// Creates a new range.
+    ///
+    /// It is user's responsibility to guarantee that `first` to `last` is a
+    /// correct range.
+    pub(crate) fn new(first: NodeId, last: NodeId) -> Self {
+        Self { first, last }
+    }
+
+    /// Detaches the range from the siblings out of the range, preserving
+    /// sibling relations inside the range.
+    pub(crate) fn detach_from_siblings<T>(self, arena: &mut Arena<T>) -> DetachedSiblingsRange {
+        // Update children's parents, siblings relations outside the range, and
+        // old parent's first and last child nodes.
+        let parent = arena[self.first].parent;
+
+        // Update siblings relations outside the range and old parent's
+        // children if necessary.
+        let prev_of_range = arena[self.first].previous_sibling.take();
+        let next_of_range = arena[self.last].next_sibling.take();
+        connect_neighbors(arena, parent, prev_of_range, next_of_range);
+
+        if cfg!(debug_assertions) {
+            debug_assert_eq!(arena[self.first].previous_sibling, None);
+            debug_assert_eq!(arena[self.last].next_sibling, None);
+            debug_assert_triangle_nodes!(arena, parent, prev_of_range, next_of_range);
+            if let Some(parent_node) = parent.map(|id| &arena[id]) {
+                debug_assert_eq!(
+                    parent_node.first_child.is_some(),
+                    parent_node.last_child.is_some()
+                );
+                debug_assert_triangle_nodes!(arena, parent, None, parent_node.first_child);
+                debug_assert_triangle_nodes!(arena, parent, parent_node.last_child, None);
+            }
+        }
+
+        DetachedSiblingsRange {
+            first: self.first,
+            last: self.last,
+        }
+    }
+}
+
+/// Detached siblings range.
+///
+/// Note that the nodes in the range has outdated parent information.
+/// It is user's responsibility to properly update them using
+/// `rewrite_parents()`.
+#[derive(Debug, Clone, Copy)]
+#[must_use = "This range can have outdated parent information and they should be updated"]
+pub(crate) struct DetachedSiblingsRange {
+    /// First node.
+    first: NodeId,
+    /// Last node.
+    last: NodeId,
+}
+
+impl DetachedSiblingsRange {
+    /// Rewrites the parents.
+    ///
+    /// # Failures
+    ///
+    /// Returns an error if the given parent is a node in the range.
+    pub(crate) fn rewrite_parents<T>(
+        &self,
+        arena: &mut Arena<T>,
+        new_parent: Option<NodeId>,
+    ) -> Result<(), ConsistencyError> {
+        // Update parents of children in the range.
+        let mut child_opt = Some(self.first);
+        while let Some(child) = child_opt {
+            if Some(child) == new_parent {
+                // Attempt to set the node itself as its parent.
+                return Err(ConsistencyError::ParentChildLoop);
+            }
+            let child_node = &mut arena[child];
+            child_node.parent = new_parent;
+            child_opt = child_node.next_sibling;
+        }
+
+        Ok(())
+    }
+
+    /// Inserts the range to the given place preserving sibling relations in
+    /// the range.
+    ///
+    /// This does `rewrite_parents()` automatically, so callers do not need to
+    /// call it manually.
+    ///
+    /// # Failures
+    ///
+    /// Returns an error if the given parent is a node in the range.
+    pub(crate) fn transplant<T>(
+        self,
+        arena: &mut Arena<T>,
+        parent: Option<NodeId>,
+        previous_sibling: Option<NodeId>,
+        next_sibling: Option<NodeId>,
+    ) -> Result<(), ConsistencyError> {
+        // Check that the given arguments are consistent.
+        if cfg!(debug_assertions) {
+            if let Some(previous_sibling) = previous_sibling {
+                debug_assert_eq!(arena[previous_sibling].parent, parent);
+            }
+            if let Some(next_sibling) = next_sibling {
+                debug_assert_eq!(arena[next_sibling].parent, parent);
+            }
+            debug_assert_triangle_nodes!(arena, parent, previous_sibling, next_sibling);
+            if let Some(parent_node) = parent.map(|id| &arena[id]) {
+                debug_assert_eq!(
+                    parent_node.first_child.is_some(),
+                    parent_node.last_child.is_some()
+                );
+            }
+        }
+
+        // Rewrite parents of the nodes in the range.
+        self.rewrite_parents(arena, parent)?;
+
+        // Connect the previous sibling and the first node in the range.
+        connect_neighbors(arena, parent, previous_sibling, Some(self.first));
+
+        // Connect the next sibling and the last node in the range.
+        connect_neighbors(arena, parent, Some(self.last), next_sibling);
+
+        // Ensure related nodes are consistent.
+        // Check only in debug build.
+        if cfg!(debug_assertions) {
+            debug_assert_triangle_nodes!(arena, parent, previous_sibling, Some(self.first));
+            debug_assert_triangle_nodes!(arena, parent, Some(self.last), next_sibling);
+            if let Some(parent_node) = parent.map(|id| &arena[id]) {
+                debug_assert!(
+                    parent_node.first_child.is_some() && parent_node.last_child.is_some(),
+                    "parent should have children (at least `self.first`)"
+                );
+                debug_assert_triangle_nodes!(arena, parent, None, parent_node.first_child);
+                debug_assert_triangle_nodes!(arena, parent, parent_node.last_child, None);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -22,42 +22,92 @@ macro_rules! impl_node_iterator {
 
 /// An iterator of references to the ancestors a given node.
 pub struct Ancestors<'a, T: 'a> {
-    pub(crate) arena: &'a Arena<T>,
-    pub(crate) node: Option<NodeId>,
+    arena: &'a Arena<T>,
+    node: Option<NodeId>,
 }
 impl_node_iterator!(Ancestors, |node: &Node<T>| node.parent);
 
+impl<'a, T> Ancestors<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
+        Self {
+            arena,
+            node: Some(current),
+        }
+    }
+}
+
 /// An iterator of references to the siblings before a given node.
 pub struct PrecedingSiblings<'a, T: 'a> {
-    pub(crate) arena: &'a Arena<T>,
-    pub(crate) node: Option<NodeId>,
+    arena: &'a Arena<T>,
+    node: Option<NodeId>,
 }
 impl_node_iterator!(PrecedingSiblings, |node: &Node<T>| node.previous_sibling);
 
+impl<'a, T> PrecedingSiblings<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
+        Self {
+            arena,
+            node: Some(current),
+        }
+    }
+}
+
 /// An iterator of references to the siblings after a given node.
 pub struct FollowingSiblings<'a, T: 'a> {
-    pub(crate) arena: &'a Arena<T>,
-    pub(crate) node: Option<NodeId>,
+    arena: &'a Arena<T>,
+    node: Option<NodeId>,
 }
 impl_node_iterator!(FollowingSiblings, |node: &Node<T>| node.next_sibling);
 
+impl<'a, T> FollowingSiblings<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
+        Self {
+            arena,
+            node: Some(current),
+        }
+    }
+}
+
 /// An iterator of references to the children of a given node.
 pub struct Children<'a, T: 'a> {
-    pub(crate) arena: &'a Arena<T>,
-    pub(crate) node: Option<NodeId>,
+    arena: &'a Arena<T>,
+    node: Option<NodeId>,
 }
 impl_node_iterator!(Children, |node: &Node<T>| node.next_sibling);
 
+impl<'a, T> Children<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
+        Self {
+            arena,
+            node: arena[current].first_child,
+        }
+    }
+}
+
 /// An iterator of references to the children of a given node, in reverse order.
 pub struct ReverseChildren<'a, T: 'a> {
-    pub(crate) arena: &'a Arena<T>,
-    pub(crate) node: Option<NodeId>,
+    arena: &'a Arena<T>,
+    node: Option<NodeId>,
 }
 impl_node_iterator!(ReverseChildren, |node: &Node<T>| node.previous_sibling);
 
-/// An iterator of references to a given node and its descendants, in tree
-/// order.
-pub struct Descendants<'a, T: 'a>(pub(crate) Traverse<'a, T>);
+impl<'a, T> ReverseChildren<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
+        Self {
+            arena,
+            node: arena[current].last_child,
+        }
+    }
+}
+
+/// An iterator of references to a given node and its descendants, in tree order.
+pub struct Descendants<'a, T: 'a>(Traverse<'a, T>);
+
+impl<'a, T> Descendants<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
+        Self(Traverse::new(arena, current))
+    }
+}
 
 impl<'a, T> Iterator for Descendants<'a, T> {
     type Item = NodeId;
@@ -92,9 +142,19 @@ pub enum NodeEdge<T> {
 /// An iterator of references to a given node and its descendants, in tree
 /// order.
 pub struct Traverse<'a, T: 'a> {
-    pub(crate) arena: &'a Arena<T>,
-    pub(crate) root: NodeId,
-    pub(crate) next: Option<NodeEdge<NodeId>>,
+    arena: &'a Arena<T>,
+    root: NodeId,
+    next: Option<NodeEdge<NodeId>>,
+}
+
+impl<'a, T> Traverse<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
+        Self {
+            arena,
+            root: current,
+            next: Some(NodeEdge::Start(current)),
+        }
+    }
 }
 
 impl<'a, T> Iterator for Traverse<'a, T> {
@@ -140,9 +200,19 @@ impl<'a, T> Iterator for Traverse<'a, T> {
 /// An iterator of references to a given node and its descendants, in reverse
 /// tree order.
 pub struct ReverseTraverse<'a, T: 'a> {
-    pub(crate) arena: &'a Arena<T>,
-    pub(crate) root: NodeId,
-    pub(crate) next: Option<NodeEdge<NodeId>>,
+    arena: &'a Arena<T>,
+    root: NodeId,
+    next: Option<NodeEdge<NodeId>>,
+}
+
+impl<'a, T> ReverseTraverse<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
+        Self {
+            arena,
+            root: current,
+            next: Some(NodeEdge::End(current)),
+        }
+    }
 }
 
 impl<'a, T> Iterator for ReverseTraverse<'a, T> {

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -8,13 +8,9 @@ macro_rules! impl_node_iterator {
             type Item = NodeId;
 
             fn next(&mut self) -> Option<NodeId> {
-                match self.node.take() {
-                    Some(node) => {
-                        self.node = $next(&self.arena[node]);
-                        Some(node)
-                    }
-                    None => None,
-                }
+                let node = self.node.take()?;
+                self.node = $next(&self.arena[node]);
+                Some(node)
             }
         }
     };
@@ -113,13 +109,10 @@ impl<'a, T> Iterator for Descendants<'a, T> {
     type Item = NodeId;
 
     fn next(&mut self) -> Option<NodeId> {
-        loop {
-            match self.0.next() {
-                Some(NodeEdge::Start(node)) => return Some(node),
-                Some(NodeEdge::End(_)) => {}
-                None => return None,
-            }
-        }
+        self.0.find_map(|edge| match edge {
+            NodeEdge::Start(node) => Some(node),
+            NodeEdge::End(_) => None,
+        })
     }
 }
 


### PR DESCRIPTION
* Improve traversing iterators.
    + Iterator internals are hidden from other modules.
    + Lowered nest level of the implementations.
* Add types to represent and manipulate sibling nodes range.
    + `SiblingsRange` is a range of sibling nodes.
    + `DetachedSiblingsRange`is a detached siblings node range.
        - Tirst node of the range does not have a previous sibling, and the last node of the range does not have a next sibling.
* Add helper functions to manipulate nodes relations.
    + `connect_neighbors()` connects the given nodes.
    + `insert_with_neighbors()` inserts the given node among the given neighbors.
* Rewrited various insertions, detach, and remove methods of `NodeId`.
    + They use `SiblingsRange` internally, and the codes are now very easy to read.
* Added more assetions to check consistency.