### PR TITLE
[Do Not Merge] PoC of cyclic previous node technique

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -56,8 +56,9 @@ impl<T> Arena<T> {
     pub fn new_node(&mut self, data: T) -> NodeId {
         let next_index1 = NonZeroUsize::new(self.nodes.len().wrapping_add(1))
             .expect("Too many nodes in the arena");
-        self.nodes.push(Node::new(data));
-        NodeId::from_non_zero_usize(next_index1)
+        let id = NodeId::from_non_zero_usize(next_index1);
+        self.nodes.push(Node::new(data, id));
+        id
     }
 
     /// Counts the number of nodes in arena and returns it.

--- a/src/id.rs
+++ b/src/id.rs
@@ -428,9 +428,9 @@ impl NodeId {
     /// // `-- (implicit)
     /// //     `-- 1_2
     ///
-    /// assert!(arena[n1_2].parent().is_none());
+    /// assert!(arena[n1_2].parent(&arena).is_none());
     /// assert!(arena[n1_2].previous_sibling(&arena).is_none());
-    /// assert!(arena[n1_2].next_sibling().is_none());
+    /// assert!(arena[n1_2].next_sibling(&arena).is_none());
     ///
     /// let mut iter = n1.descendants(&arena);
     /// assert_eq!(iter.next(), Some(n1));

--- a/src/node.rs
+++ b/src/node.rs
@@ -72,12 +72,12 @@ impl<T> Node<T> {
     /// //     |-- 1_1
     /// //     |-- 1_2
     /// //     `-- 1_3
-    /// assert_eq!(arena[n1].parent(), None);
-    /// assert_eq!(arena[n1_1].parent(), Some(n1));
-    /// assert_eq!(arena[n1_2].parent(), Some(n1));
-    /// assert_eq!(arena[n1_3].parent(), Some(n1));
+    /// assert_eq!(arena[n1].parent(&arena), None);
+    /// assert_eq!(arena[n1_1].parent(&arena), Some(n1));
+    /// assert_eq!(arena[n1_2].parent(&arena), Some(n1));
+    /// assert_eq!(arena[n1_3].parent(&arena), Some(n1));
     /// ```
-    pub fn parent(&self) -> Option<NodeId> {
+    pub fn parent(&self, _arena: &Arena<T>) -> Option<NodeId> {
         self.parent
     }
 
@@ -100,12 +100,12 @@ impl<T> Node<T> {
     /// //     |-- 1_1
     /// //     |-- 1_2
     /// //     `-- 1_3
-    /// assert_eq!(arena[n1].first_child(), Some(n1_1));
-    /// assert_eq!(arena[n1_1].first_child(), None);
-    /// assert_eq!(arena[n1_2].first_child(), None);
-    /// assert_eq!(arena[n1_3].first_child(), None);
+    /// assert_eq!(arena[n1].first_child(&arena), Some(n1_1));
+    /// assert_eq!(arena[n1_1].first_child(&arena), None);
+    /// assert_eq!(arena[n1_2].first_child(&arena), None);
+    /// assert_eq!(arena[n1_3].first_child(&arena), None);
     /// ```
-    pub fn first_child(&self) -> Option<NodeId> {
+    pub fn first_child(&self, _arena: &Arena<T>) -> Option<NodeId> {
         self.first_child
     }
 
@@ -219,10 +219,10 @@ impl<T> Node<T> {
     /// //     |-- 1_1
     /// //     |-- 1_2
     /// //     `-- 1_3
-    /// assert_eq!(arena[n1].next_sibling(), None);
-    /// assert_eq!(arena[n1_1].next_sibling(), Some(n1_2));
-    /// assert_eq!(arena[n1_2].next_sibling(), Some(n1_3));
-    /// assert_eq!(arena[n1_3].next_sibling(), None);
+    /// assert_eq!(arena[n1].next_sibling(&arena), None);
+    /// assert_eq!(arena[n1_1].next_sibling(&arena), Some(n1_2));
+    /// assert_eq!(arena[n1_2].next_sibling(&arena), Some(n1_3));
+    /// assert_eq!(arena[n1_3].next_sibling(&arena), None);
     /// ```
     ///
     /// Note that newly created nodes are independent toplevel nodes, and they
@@ -238,18 +238,18 @@ impl<T> Node<T> {
     /// // |   `-- 1
     /// // `-- (implicit)
     /// //     `-- 2
-    /// assert_eq!(arena[n1].next_sibling(), None);
-    /// assert_eq!(arena[n2].next_sibling(), None);
+    /// assert_eq!(arena[n1].next_sibling(&arena), None);
+    /// assert_eq!(arena[n2].next_sibling(&arena), None);
     ///
     /// n1.insert_after(n2, &mut arena);
     /// // arena
     /// // `-- (implicit)
     /// //     |-- 1
     /// //     `-- 2
-    /// assert_eq!(arena[n1].next_sibling(), Some(n2));
-    /// assert_eq!(arena[n2].next_sibling(), None);
+    /// assert_eq!(arena[n1].next_sibling(&arena), Some(n2));
+    /// assert_eq!(arena[n2].next_sibling(&arena), None);
     /// ```
-    pub fn next_sibling(&self) -> Option<NodeId> {
+    pub fn next_sibling(&self, _arena: &Arena<T>) -> Option<NodeId> {
         self.next_sibling
     }
 
@@ -272,8 +272,8 @@ impl<T> Node<T> {
     /// //     |-- 1_1
     /// //     |-- 1_2 *
     /// //     `-- 1_3
-    /// assert_eq!(arena[n1_1].next_sibling(), Some(n1_2));
-    /// assert_eq!(arena[n1_2].parent(), Some(n1));
+    /// assert_eq!(arena[n1_1].next_sibling(&arena), Some(n1_2));
+    /// assert_eq!(arena[n1_2].parent(&arena), Some(n1));
     /// assert!(!arena[n1_2].is_removed());
     /// assert_eq!(arena[n1_3].previous_sibling(&arena), Some(n1_2));
     ///
@@ -282,8 +282,8 @@ impl<T> Node<T> {
     /// // `-- 1
     /// //     |-- 1_1
     /// //     `-- 1_3
-    /// assert_eq!(arena[n1_1].next_sibling(), Some(n1_3));
-    /// assert_eq!(arena[n1_2].parent(), None);
+    /// assert_eq!(arena[n1_1].next_sibling(&arena), Some(n1_3));
+    /// assert_eq!(arena[n1_2].parent(&arena), None);
     /// assert!(arena[n1_2].is_removed());
     /// assert_eq!(arena[n1_3].previous_sibling(&arena), Some(n1_1));
     /// ```

--- a/src/siblings_range.rs
+++ b/src/siblings_range.rs
@@ -29,21 +29,23 @@ impl SiblingsRange {
 
         // Update siblings relations outside the range and old parent's
         // children if necessary.
-        let prev_of_range = arena[self.first].previous_sibling.take();
+        //let prev_of_range = arena[self.first].previous_sibling.take(); // FIXME
+        let prev_of_range = arena[self.first].previous_sibling(arena);
+        arena[self.first].cyclic_previous_sibling = self.last;
         let next_of_range = arena[self.last].next_sibling.take();
         connect_neighbors(arena, parent, prev_of_range, next_of_range);
 
         if cfg!(debug_assertions) {
-            debug_assert_eq!(arena[self.first].previous_sibling, None);
+            debug_assert_eq!(arena[self.first].previous_sibling(arena), None);
             debug_assert_eq!(arena[self.last].next_sibling, None);
             debug_assert_triangle_nodes!(arena, parent, prev_of_range, next_of_range);
             if let Some(parent_node) = parent.map(|id| &arena[id]) {
                 debug_assert_eq!(
                     parent_node.first_child.is_some(),
-                    parent_node.last_child.is_some()
+                    parent_node.last_child(arena).is_some()
                 );
                 debug_assert_triangle_nodes!(arena, parent, None, parent_node.first_child);
-                debug_assert_triangle_nodes!(arena, parent, parent_node.last_child, None);
+                debug_assert_triangle_nodes!(arena, parent, parent_node.last_child(arena), None);
             }
         }
 
@@ -122,7 +124,7 @@ impl DetachedSiblingsRange {
             if let Some(parent_node) = parent.map(|id| &arena[id]) {
                 debug_assert_eq!(
                     parent_node.first_child.is_some(),
-                    parent_node.last_child.is_some()
+                    parent_node.last_child(arena).is_some()
                 );
             }
         }
@@ -143,11 +145,11 @@ impl DetachedSiblingsRange {
             debug_assert_triangle_nodes!(arena, parent, Some(self.last), next_sibling);
             if let Some(parent_node) = parent.map(|id| &arena[id]) {
                 debug_assert!(
-                    parent_node.first_child.is_some() && parent_node.last_child.is_some(),
+                    parent_node.first_child.is_some() && parent_node.last_child(arena).is_some(),
                     "parent should have children (at least `self.first`)"
                 );
                 debug_assert_triangle_nodes!(arena, parent, None, parent_node.first_child);
-                debug_assert_triangle_nodes!(arena, parent, parent_node.last_child, None);
+                debug_assert_triangle_nodes!(arena, parent, parent_node.last_child(arena), None);
             }
         }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,7 +26,7 @@ fn success_create() {
     let c = new!(); // 10
     assert!(b.checked_append(c, arena).is_ok());
 
-    arena[c].previous_sibling().unwrap().detach(arena);
+    arena[c].previous_sibling(&arena).unwrap().detach(arena);
 
     assert_eq!(
         b.descendants(arena)

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -28,7 +28,7 @@ fn toplevel_with_single_child() {
     n1.remove(&mut arena);
     // arena
     // `-- 1_1
-    assert!(arena[n1_1].parent().is_none());
+    assert!(arena[n1_1].parent(&arena).is_none());
 }
 
 #[test]
@@ -58,8 +58,8 @@ fn toplevel_with_multiple_children() {
     // arena
     // |-- 1_1
     // `-- 1_2
-    assert!(arena[n1_1].parent().is_none());
-    assert!(arena[n1_2].parent().is_none());
+    assert!(arena[n1_1].parent(&arena).is_none());
+    assert!(arena[n1_2].parent(&arena).is_none());
     assert_eq!(
         n1_1.following_siblings(&arena).collect::<Vec<_>>(),
         &[n1_1, n1_2]
@@ -82,7 +82,7 @@ fn single_child_with_no_children() {
     n1_1.remove(&mut arena);
     // arena
     // `-- 1
-    assert!(arena[n1_1].parent().is_none());
+    assert!(arena[n1_1].parent(&arena).is_none());
     assert_eq!(
         n1.traverse(&arena).collect::<Vec<_>>(),
         &[Start(n1), End(n1),]
@@ -116,8 +116,8 @@ fn single_child_with_single_child() {
     // arena
     // `-- 1
     //     `-- 1_1_1
-    assert!(arena[n1_1].parent().is_none());
-    assert!(arena[n1_1].first_child().is_none());
+    assert!(arena[n1_1].parent(&arena).is_none());
+    assert!(arena[n1_1].first_child(&arena).is_none());
     assert_eq!(n1_1_1.ancestors(&arena).collect::<Vec<_>>(), &[n1_1_1, n1]);
     assert_eq!(
         n1.traverse(&arena).collect::<Vec<_>>(),


### PR DESCRIPTION
This is a PoC implementation of #12.

I noticed:
* Updating neighbors are O(1) cost, **if all the nodes have parents**.
    + `indextree` does not provide implicit root nodes, and toplevel nodes can have siblings without parents.
      For such nodes, updating neighbors are O(`num_of_siblings`).
      <https://github.com/saschagrunert/indextree/blob/8e7fafa1c2bca83430192733ae137eba7e7ec1e3/src/relations.rs#L83-L90>
* Now all neighors getters (such as `Node::parent()`) should receive `&Arena<T>`.
  This is not intrinsic difficutly, because when people wanted to get `NodeId` from `Node<T>`, then they would have `&Arena<T>`.
  (However, I feel it is just annoying to pass `&arena` as an argument all the time).

If this change is worth merging, then I think `indextree` should support some mechanism for pseudo-parent node or implicit root node to make updates constant time.