### PR TITLE
Drop dependency for `failure` crate, and make `NodeId::remove()` infallible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ par_iter = ["rayon"]
 std = []
 
 [dependencies]
-failure = { version = "0.1.5", features = ["derive"] }
 rayon = { version = "1.0.3", optional = true }
 serde = { version = "1.0.90", features = ["derive"], optional = true }
 

--- a/examples/parallel_iteration.rs
+++ b/examples/parallel_iteration.rs
@@ -1,8 +1,7 @@
-use failure::Fallible;
 use indextree::*;
 use rayon::prelude::*;
 
-pub fn main() -> Fallible<()> {
+pub fn main() -> Result<(), NodeError> {
     // Create a new arena
     let arena = &mut Arena::new();
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -82,9 +82,8 @@ impl<T> Arena<T> {
     /// let _bar = arena.new_node("bar");
     /// assert_eq!(arena.count(), 2);
     ///
-    /// let _ = foo.remove(&mut arena)?;
+    /// foo.remove(&mut arena);
     /// assert_eq!(arena.count(), 2);
-    /// # Ok::<(), failure::Error>(())
     /// ```
     pub fn count(&self) -> usize {
         self.nodes.len()
@@ -102,9 +101,8 @@ impl<T> Arena<T> {
     /// let foo = arena.new_node("foo");
     /// assert!(!arena.is_empty());
     ///
-    /// foo.remove(&mut arena)?;
+    /// foo.remove(&mut arena);
     /// assert!(!arena.is_empty());
-    /// # Ok::<(), failure::Error>(())
     /// ```
     pub fn is_empty(&self) -> bool {
         self.count() == 0
@@ -190,13 +188,12 @@ impl<T> Arena<T> {
     /// let mut arena = Arena::new();
     /// let _foo = arena.new_node("foo");
     /// let bar = arena.new_node("bar");
-    /// bar.remove(&mut arena)?;
+    /// bar.remove(&mut arena);
     ///
     /// let mut iter = arena.iter();
     /// assert_eq!(iter.next().map(|node| (node.data, node.is_removed())), Some(("foo", false)));
     /// assert_eq!(iter.next().map(|node| (node.data, node.is_removed())), Some(("bar", true)));
     /// assert_eq!(iter.next().map(|node| (node.data, node.is_removed())), None);
-    /// # Ok::<(), failure::Error>(())
     /// ```
     ///
     /// [`is_removed()`]: struct.Node.html#method.is_removed

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,70 +3,41 @@
 #[cfg(not(feature = "std"))]
 use core::fmt;
 
-use failure::Fail;
-
 #[cfg(feature = "std")]
 use std::{error, fmt};
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Clone, Copy)]
 /// Possible node failures.
 pub enum NodeError {
-    #[fail(display = "Can not append a node to itself")]
+    /// Attempt to append a node to itself.
     AppendSelf,
-
-    #[fail(display = "Can not prepend a node to itself")]
+    /// Attempt to prepend a node to itself.
     PrependSelf,
-
-    #[fail(display = "Can not insert a node before itself")]
+    /// Attempt to insert a node before itself.
     InsertBeforeSelf,
-
-    #[fail(display = "Can not insert a node after itself")]
+    /// Attempt to insert a node after itself.
     InsertAfterSelf,
-
-    // Deprecated, no longer used.
-    #[fail(display = "First child is already set")]
-    FirstChildAlreadySet,
-
-    // Deprecated, no longer used.
-    #[fail(display = "Previous sibling is already set")]
-    PreviousSiblingAlreadySet,
-
-    // Deprecated, no longer used.
-    #[fail(display = "Next sibling is already set")]
-    NextSiblingAlreadySet,
-
-    // Deprecated, no longer used.
-    #[fail(display = "Previous sibling not equal current node")]
-    PreviousSiblingNotSelf,
-
-    // Deprecated, no longer used.
-    #[fail(display = "Next sibling not equal current node")]
-    NextSiblingNotSelf,
-
-    // Deprecated, no longer used.
-    #[fail(display = "First child not equal current node")]
-    FirstChildNotSelf,
-
-    // Deprecated, no longer used.
-    #[fail(display = "Last child not equal current node")]
-    LastChildNotSelf,
-
-    // Deprecated, no longer used.
-    #[fail(display = "Previous sibling is not set")]
-    PreviousSiblingNotSet,
-
-    // Deprecated, no longer used.
-    #[fail(display = "Next sibling is not set")]
-    NextSiblingNotSet,
-
-    // Deprecated, no longer used.
-    #[fail(display = "First child is not set")]
-    FirstChildNotSet,
-
-    // Deprecated, no longer used.
-    #[fail(display = "Last child is not set")]
-    LastChildNotSet,
 }
+
+impl NodeError {
+    fn as_str(self) -> &'static str {
+        match self {
+            NodeError::AppendSelf => "Can not append a node to itself",
+            NodeError::PrependSelf => "Can not prepend a node to itself",
+            NodeError::InsertBeforeSelf => "Can not insert a node before itself",
+            NodeError::InsertAfterSelf => "Can not insert a node after itself",
+        }
+    }
+}
+
+impl fmt::Display for NodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "std")]
+impl error::Error for NodeError {}
 
 /// An error type that represents the given structure or argument is
 /// inconsistent or invalid.

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,9 @@ pub enum NodeError {
     InsertBeforeSelf,
     /// Attempt to insert a node after itself.
     InsertAfterSelf,
+    // See <https://github.com/rust-lang/rfcs/blob/master/text/2008-non-exhaustive.md#how-we-do-this-today>.
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl NodeError {
@@ -26,6 +29,7 @@ impl NodeError {
             NodeError::PrependSelf => "Can not prepend a node to itself",
             NodeError::InsertBeforeSelf => "Can not insert a node before itself",
             NodeError::InsertAfterSelf => "Can not insert a node after itself",
+            NodeError::__Nonexhaustive => panic!("`__Nonexhaustive` should not be used"),
         }
     }
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -725,7 +725,7 @@ impl NodeId {
     /// //     |   `-- 1_2_2
     /// //     `-- 1_3
     ///
-    /// n1_2.remove(&mut arena)?;
+    /// n1_2.remove(&mut arena);
     ///
     /// let mut iter = n1.descendants(&arena);
     /// assert_eq!(iter.next(), Some(n1));
@@ -734,11 +734,10 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_2_2));
     /// assert_eq!(iter.next(), Some(n1_3));
     /// assert_eq!(iter.next(), None);
-    /// # Ok::<(), failure::Error>(())
     /// ```
     ///
     /// [`Node::is_removed()`]: struct.Node.html#method.is_removed
-    pub fn remove<T>(self, arena: &mut Arena<T>) -> Fallible<()> {
+    pub fn remove<T>(self, arena: &mut Arena<T>) {
         debug_assert_triangle_nodes!(
             arena,
             arena[self].parent,
@@ -776,7 +775,5 @@ impl NodeId {
         }
         arena[self].removed = true;
         debug_assert!(arena[self].is_detached());
-
-        Ok(())
     }
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -105,15 +105,15 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
     /// # let n1_1_1_1 = arena.new_node("1_1_1_1");
-    /// # n1_1_1.append(n1_1_1_1, &mut arena);
+    /// # n1_1_1.append(n1_1_1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// // arena
     /// // `-- 1
@@ -148,13 +148,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// // arena
     /// // `-- 1
@@ -187,13 +187,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// // arena
     /// // `-- 1
@@ -222,13 +222,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// // arena
     /// // `-- 1
@@ -257,13 +257,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// // arena
     /// // `-- 1
@@ -296,15 +296,15 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
     /// # let n1_1_1_1 = arena.new_node("1_1_1_1");
-    /// # n1_1_1.append(n1_1_1_1, &mut arena);
+    /// # n1_1_1.append(n1_1_1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// // arena
     /// // `-- 1
@@ -339,13 +339,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// // arena
     /// // `-- 1
@@ -381,13 +381,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// // arena
     /// // `-- 1
@@ -415,13 +415,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// # // arena
     /// # // `-- 1
@@ -448,13 +448,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena);
+    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// // arena
     /// // `-- (implicit)
@@ -511,11 +511,11 @@ impl NodeId {
     /// let mut arena = Arena::new();
     /// let n1 = arena.new_node("1");
     /// let n1_1 = arena.new_node("1_1");
-    /// n1.append(n1_1, &mut arena);
+    /// n1.append(n1_1, &mut arena).unwrap();
     /// let n1_2 = arena.new_node("1_2");
-    /// n1.append(n1_2, &mut arena);
+    /// n1.append(n1_2, &mut arena).unwrap();
     /// let n1_3 = arena.new_node("1_3");
-    /// n1.append(n1_3, &mut arena);
+    /// n1.append(n1_3, &mut arena).unwrap();
     ///
     /// // arena
     /// // `-- 1
@@ -554,11 +554,11 @@ impl NodeId {
     /// let mut arena = Arena::new();
     /// let n1 = arena.new_node("1");
     /// let n1_1 = arena.new_node("1_1");
-    /// n1.prepend(n1_1, &mut arena);
+    /// n1.prepend(n1_1, &mut arena).unwrap();
     /// let n1_2 = arena.new_node("1_2");
-    /// n1.prepend(n1_2, &mut arena);
+    /// n1.prepend(n1_2, &mut arena).unwrap();
     /// let n1_3 = arena.new_node("1_3");
-    /// n1.prepend(n1_3, &mut arena);
+    /// n1.prepend(n1_3, &mut arena).unwrap();
     ///
     /// // arena
     /// // `-- 1
@@ -596,9 +596,9 @@ impl NodeId {
     /// let mut arena = Arena::new();
     /// let n1 = arena.new_node("1");
     /// let n1_1 = arena.new_node("1_1");
-    /// n1.append(n1_1, &mut arena);
+    /// n1.append(n1_1, &mut arena).unwrap();
     /// let n1_2 = arena.new_node("1_2");
-    /// n1.append(n1_2, &mut arena);
+    /// n1.append(n1_2, &mut arena).unwrap();
     ///
     /// // arena
     /// // `-- 1
@@ -606,7 +606,7 @@ impl NodeId {
     /// //     `-- 1_2
     ///
     /// let n1_3 = arena.new_node("1_3");
-    /// n1_1.insert_after(n1_3, &mut arena);
+    /// n1_1.insert_after(n1_3, &mut arena).unwrap();
     ///
     /// // arena
     /// // `-- 1
@@ -649,9 +649,9 @@ impl NodeId {
     /// let mut arena = Arena::new();
     /// let n1 = arena.new_node("1");
     /// let n1_1 = arena.new_node("1_1");
-    /// n1.append(n1_1, &mut arena);
+    /// n1.append(n1_1, &mut arena).unwrap();
     /// let n1_2 = arena.new_node("1_2");
-    /// n1.append(n1_2, &mut arena);
+    /// n1.append(n1_2, &mut arena).unwrap();
     ///
     /// // arena
     /// // `-- 1
@@ -659,7 +659,7 @@ impl NodeId {
     /// //     `-- 1_2
     ///
     /// let n1_3 = arena.new_node("1_3");
-    /// n1_2.insert_before(n1_3, &mut arena);
+    /// n1_2.insert_before(n1_3, &mut arena).unwrap();
     ///
     /// // arena
     /// // `-- 1
@@ -707,15 +707,15 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_2_1 = arena.new_node("1_2_1");
-    /// # n1_2.append(n1_2_1, &mut arena);
+    /// # n1_2.append(n1_2_1, &mut arena).unwrap();
     /// # let n1_2_2 = arena.new_node("1_2_2");
-    /// # n1_2.append(n1_2_2, &mut arena);
+    /// # n1_2.append(n1_2_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// #
     /// // arena
     /// // `-- 1

--- a/src/id.rs
+++ b/src/id.rs
@@ -3,8 +3,6 @@
 #[cfg(not(feature = "std"))]
 use core::{fmt, num::NonZeroUsize};
 
-use failure::{bail, Fallible};
-
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
@@ -530,9 +528,9 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_3));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn append<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
+    pub fn append<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Result<(), NodeError> {
         if new_child == self {
-            bail!(NodeError::AppendSelf);
+            return Err(NodeError::AppendSelf);
         }
         new_child.detach(arena);
         insert_with_neighbors(arena, new_child, Some(self), arena[self].last_child, None)
@@ -573,9 +571,9 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_1));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn prepend<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
+    pub fn prepend<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Result<(), NodeError> {
         if new_child == self {
-            bail!(NodeError::PrependSelf);
+            return Err(NodeError::PrependSelf);
         }
         insert_with_neighbors(arena, new_child, Some(self), None, arena[self].first_child)
             .expect("Should never fail: `new_child` is not `self`");
@@ -621,9 +619,13 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_2));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn insert_after<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
+    pub fn insert_after<T>(
+        self,
+        new_sibling: NodeId,
+        arena: &mut Arena<T>,
+    ) -> Result<(), NodeError> {
         if new_sibling == self {
-            bail!(NodeError::InsertAfterSelf);
+            return Err(NodeError::InsertAfterSelf);
         }
         new_sibling.detach(arena);
         let (next_sibling, parent) = {
@@ -674,9 +676,13 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_2));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn insert_before<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) -> Fallible<()> {
+    pub fn insert_before<T>(
+        self,
+        new_sibling: NodeId,
+        arena: &mut Arena<T>,
+    ) -> Result<(), NodeError> {
         if new_sibling == self {
-            bail!(NodeError::InsertBeforeSelf);
+            return Err(NodeError::InsertBeforeSelf);
         }
         new_sibling.detach(arena);
         let (previous_sibling, parent) = {

--- a/src/node.rs
+++ b/src/node.rs
@@ -247,7 +247,7 @@ impl<T> Node<T> {
     /// assert!(!arena[n1_2].is_removed());
     /// assert_eq!(arena[n1_3].previous_sibling(), Some(n1_2));
     ///
-    /// n1_2.remove(&mut arena)?;
+    /// n1_2.remove(&mut arena);
     /// // arena
     /// // `-- 1
     /// //     |-- 1_1
@@ -256,7 +256,6 @@ impl<T> Node<T> {
     /// assert_eq!(arena[n1_2].parent(), None);
     /// assert!(arena[n1_2].is_removed());
     /// assert_eq!(arena[n1_3].previous_sibling(), Some(n1_1));
-    /// # Ok::<(), failure::Error>(())
     /// ```
     pub fn is_removed(&self) -> bool {
         self.removed

--- a/src/node.rs
+++ b/src/node.rs
@@ -157,14 +157,13 @@ impl<T> Node<T> {
     /// assert_eq!(arena[n1].previous_sibling(), None);
     /// assert_eq!(arena[n2].previous_sibling(), None);
     ///
-    /// n1.insert_after(n2, &mut arena)?;
+    /// n1.insert_after(n2, &mut arena).unwrap();
     /// // arena
     /// // `-- (implicit)
     /// //     |-- 1
     /// //     `-- 2
     /// assert_eq!(arena[n1].previous_sibling(), None);
     /// assert_eq!(arena[n2].previous_sibling(), Some(n1));
-    /// # Ok::<(), failure::Error>(())
     /// ```
     pub fn previous_sibling(&self) -> Option<NodeId> {
         self.previous_sibling
@@ -212,14 +211,13 @@ impl<T> Node<T> {
     /// assert_eq!(arena[n1].next_sibling(), None);
     /// assert_eq!(arena[n2].next_sibling(), None);
     ///
-    /// n1.insert_after(n2, &mut arena)?;
+    /// n1.insert_after(n2, &mut arena).unwrap();
     /// // arena
     /// // `-- (implicit)
     /// //     |-- 1
     /// //     `-- 2
     /// assert_eq!(arena[n1].next_sibling(), Some(n2));
     /// assert_eq!(arena[n2].next_sibling(), None);
-    /// # Ok::<(), failure::Error>(())
     /// ```
     pub fn next_sibling(&self) -> Option<NodeId> {
         self.next_sibling
@@ -234,11 +232,11 @@ impl<T> Node<T> {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena);
+    /// # n1.append(n1_1, &mut arena).unwrap();
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena);
+    /// # n1.append(n1_2, &mut arena).unwrap();
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena);
+    /// # n1.append(n1_3, &mut arena).unwrap();
     /// // arena
     /// // `-- 1
     /// //     |-- 1_1

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -118,7 +118,7 @@ fn remove() {
     assert!(n2.append(n5, arena).is_ok());
     assert!(n2.append(n5, arena).is_ok());
     assert!(n2.append(n6, arena).is_ok());
-    assert!(n2.remove(arena).is_ok());
+    n2.remove(arena);
 
     let node_refs = arena
         .iter()
@@ -130,7 +130,7 @@ fn remove() {
     assert_eq!(n2.preceding_siblings(arena).collect::<Vec<_>>().len(), 1);
     assert_eq!(n2.following_siblings(arena).collect::<Vec<_>>().len(), 1);
 
-    assert!(n3.remove(arena).is_ok());
+    n3.remove(arena);
 
     let node_refs = arena
         .iter()

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -9,7 +9,7 @@ fn toplevel_with_no_child() {
     let n1 = arena.new_node("1");
     // arena
     // `-- 1
-    assert!(n1.remove(&mut arena).is_ok());
+    n1.remove(&mut arena);
 }
 
 #[test]
@@ -25,7 +25,7 @@ fn toplevel_with_single_child() {
         n1.traverse(&arena).collect::<Vec<_>>(),
         &[Start(n1), Start(n1_1), End(n1_1), End(n1)]
     );
-    n1.remove(&mut arena).unwrap();
+    n1.remove(&mut arena);
     // arena
     // `-- 1_1
     assert!(arena[n1_1].parent().is_none());
@@ -54,7 +54,7 @@ fn toplevel_with_multiple_children() {
             End(n1)
         ]
     );
-    n1.remove(&mut arena).unwrap();
+    n1.remove(&mut arena);
     // arena
     // |-- 1_1
     // `-- 1_2
@@ -79,7 +79,7 @@ fn single_child_with_no_children() {
         n1.traverse(&arena).collect::<Vec<_>>(),
         &[Start(n1), Start(n1_1), End(n1_1), End(n1),]
     );
-    n1_1.remove(&mut arena).unwrap();
+    n1_1.remove(&mut arena);
     // arena
     // `-- 1
     assert!(arena[n1_1].parent().is_none());
@@ -112,7 +112,7 @@ fn single_child_with_single_child() {
             End(n1),
         ]
     );
-    n1_1.remove(&mut arena).unwrap();
+    n1_1.remove(&mut arena);
     // arena
     // `-- 1
     //     `-- 1_1_1
@@ -153,7 +153,7 @@ fn first_child_with_no_children() {
             End(n1),
         ]
     );
-    n1_1.remove(&mut arena).unwrap();
+    n1_1.remove(&mut arena);
     // arena
     // `-- 1
     //     |-- 1_2
@@ -199,7 +199,7 @@ fn middle_child_with_no_children() {
             End(n1),
         ]
     );
-    n1_2.remove(&mut arena).unwrap();
+    n1_2.remove(&mut arena);
     // arena
     // `-- 1
     //     |-- 1_1
@@ -245,7 +245,7 @@ fn last_child_with_no_children() {
             End(n1),
         ]
     );
-    n1_3.remove(&mut arena).unwrap();
+    n1_3.remove(&mut arena);
     // arena
     // `-- 1
     //     |-- 1_1
@@ -296,7 +296,7 @@ fn middle_child_with_single_child() {
             End(n1),
         ]
     );
-    n1_2.remove(&mut arena).unwrap();
+    n1_2.remove(&mut arena);
     // arena
     // `-- 1
     //     |-- 1_1
@@ -360,7 +360,7 @@ fn middle_child_with_multiple_children() {
             End(n1),
         ]
     );
-    n1_2.remove(&mut arena).unwrap();
+    n1_2.remove(&mut arena);
     // arena
     // `-- 1
     //     |-- 1_1


### PR DESCRIPTION
This is breaking change.

`failure` brings some dependencies, but errors in `indextree` is quite simple ("preconditions are not met"), and it is almost unnecessary.

* `NodeId::remove()` is now infallible.
    + It does not fail in any situation, until indextree has inconsistency bug.
* `NodeId::insert_{before,after}`, `NodeId::{prepend,append}` now returns `Result<(), NodeError>` instead of `failure::Fallible<()>`.
    + I believe no one needs powerful features of `failure` crate for these simple errors.
* Examples in docs are a little improved.
    + Uses of insertions in the examples won't fail, so use `.unwrap()` explicitly, intead of using `?` operator.