### PR TITLE
More derives by default, and remove `derive-eq` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ appveyor = { repository = "saschagrunert/indextree", branch = "master", service 
 [features]
 default = ["std"]
 deser = [ "serde" ]
-derive-eq = []
 par_iter = ["rayon"]
 std = []
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -25,9 +25,8 @@ use std::{
 
 use crate::{Node, NodeId};
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "derive-eq", derive(Eq))]
 /// An `Arena` structure containing certain [`Node`]s.
 ///
 /// [`Node`]: struct.Node.html

--- a/src/node.rs
+++ b/src/node.rs
@@ -11,9 +11,8 @@ use std::fmt;
 
 use crate::NodeId;
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "derive-eq", derive(Eq))]
 /// A node within a particular `Arena`.
 pub struct Node<T> {
     // Keep these private (with read-only accessors) so that we can keep them

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -16,6 +16,7 @@ macro_rules! impl_node_iterator {
     };
 }
 
+#[derive(Clone)]
 /// An iterator of references to the ancestors a given node.
 pub struct Ancestors<'a, T: 'a> {
     arena: &'a Arena<T>,
@@ -32,6 +33,7 @@ impl<'a, T> Ancestors<'a, T> {
     }
 }
 
+#[derive(Clone)]
 /// An iterator of references to the siblings before a given node.
 pub struct PrecedingSiblings<'a, T: 'a> {
     arena: &'a Arena<T>,
@@ -48,6 +50,7 @@ impl<'a, T> PrecedingSiblings<'a, T> {
     }
 }
 
+#[derive(Clone)]
 /// An iterator of references to the siblings after a given node.
 pub struct FollowingSiblings<'a, T: 'a> {
     arena: &'a Arena<T>,
@@ -64,6 +67,7 @@ impl<'a, T> FollowingSiblings<'a, T> {
     }
 }
 
+#[derive(Clone)]
 /// An iterator of references to the children of a given node.
 pub struct Children<'a, T: 'a> {
     arena: &'a Arena<T>,
@@ -80,6 +84,7 @@ impl<'a, T> Children<'a, T> {
     }
 }
 
+#[derive(Clone)]
 /// An iterator of references to the children of a given node, in reverse order.
 pub struct ReverseChildren<'a, T: 'a> {
     arena: &'a Arena<T>,
@@ -96,6 +101,7 @@ impl<'a, T> ReverseChildren<'a, T> {
     }
 }
 
+#[derive(Clone)]
 /// An iterator of references to a given node and its descendants, in tree order.
 pub struct Descendants<'a, T: 'a>(Traverse<'a, T>);
 
@@ -132,6 +138,7 @@ pub enum NodeEdge<T> {
     End(T),
 }
 
+#[derive(Clone)]
 /// An iterator of references to a given node and its descendants, in tree
 /// order.
 pub struct Traverse<'a, T: 'a> {
@@ -183,6 +190,7 @@ impl<'a, T> Iterator for Traverse<'a, T> {
     }
 }
 
+#[derive(Clone)]
 /// An iterator of references to a given node and its descendants, in reverse
 /// tree order.
 pub struct ReverseTraverse<'a, T: 'a> {


### PR DESCRIPTION
This is breaking change.

* `derive-eq` feature is removed and `Eq` is implemented for some types by default.
* Implement `Clone` for iterators.
    + Not implementing `Copy`. See [rust - Why are iterators not copyable? - Stack Overflow](https://stackoverflow.com/questions/32324251/why-are-iterators-not-copyable#32324592).