### PR TITLE
Add `checked_*` version of node insertions

### DIFF
--- a/examples/parallel_iteration.rs
+++ b/examples/parallel_iteration.rs
@@ -1,7 +1,7 @@
 use indextree::*;
 use rayon::prelude::*;
 
-pub fn main() -> Result<(), NodeError> {
+pub fn main() {
     // Create a new arena
     let arena = &mut Arena::new();
 
@@ -10,7 +10,7 @@ pub fn main() -> Result<(), NodeError> {
     let mut last_node = arena.new_node(1);
     for i in 1..10_000_000 {
         let node = arena.new_node(i);
-        node.append(last_node, arena)?;
+        node.append(last_node, arena);
         last_node = node;
     }
 
@@ -19,6 +19,4 @@ pub fn main() -> Result<(), NodeError> {
         .par_iter()
         .map(|ref mut i| (i.data as f64).sqrt())
         .collect();
-
-    Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -9,6 +9,6 @@ pub fn main() {
     let b = arena.new_node(2);
 
     // Append a to b
-    assert!(a.append(b, arena).is_ok());
+    a.append(b, arena);
     assert_eq!(b.ancestors(arena).into_iter().count(), 2);
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -103,15 +103,15 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
+    /// # n1_1.append(n1_1_1, &mut arena);
     /// # let n1_1_1_1 = arena.new_node("1_1_1_1");
-    /// # n1_1_1.append(n1_1_1_1, &mut arena).unwrap();
+    /// # n1_1_1.append(n1_1_1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// // arena
     /// // `-- 1
@@ -146,13 +146,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
+    /// # n1_1.append(n1_1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// // arena
     /// // `-- 1
@@ -185,13 +185,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
+    /// # n1_1.append(n1_1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// // arena
     /// // `-- 1
@@ -220,13 +220,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
+    /// # n1_1.append(n1_1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// // arena
     /// // `-- 1
@@ -255,13 +255,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
+    /// # n1_1.append(n1_1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// // arena
     /// // `-- 1
@@ -294,15 +294,15 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
+    /// # n1_1.append(n1_1_1, &mut arena);
     /// # let n1_1_1_1 = arena.new_node("1_1_1_1");
-    /// # n1_1_1.append(n1_1_1_1, &mut arena).unwrap();
+    /// # n1_1_1.append(n1_1_1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// // arena
     /// // `-- 1
@@ -337,13 +337,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
+    /// # n1_1.append(n1_1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// // arena
     /// // `-- 1
@@ -379,13 +379,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
+    /// # n1_1.append(n1_1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// // arena
     /// // `-- 1
@@ -413,13 +413,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
+    /// # n1_1.append(n1_1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// # // arena
     /// # // `-- 1
@@ -446,13 +446,13 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_1_1 = arena.new_node("1_1_1");
-    /// # n1_1.append(n1_1_1, &mut arena).unwrap();
+    /// # n1_1.append(n1_1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// // arena
     /// // `-- (implicit)
@@ -498,7 +498,7 @@ impl NodeId {
 
     /// Appends a new child to this node, after existing children.
     ///
-    /// # Failures
+    /// # Panics
     ///
     /// Returns an error if the given new child is `self`.
     ///
@@ -509,11 +509,11 @@ impl NodeId {
     /// let mut arena = Arena::new();
     /// let n1 = arena.new_node("1");
     /// let n1_1 = arena.new_node("1_1");
-    /// n1.append(n1_1, &mut arena).unwrap();
+    /// n1.append(n1_1, &mut arena);
     /// let n1_2 = arena.new_node("1_2");
-    /// n1.append(n1_2, &mut arena).unwrap();
+    /// n1.append(n1_2, &mut arena);
     /// let n1_3 = arena.new_node("1_3");
-    /// n1.append(n1_3, &mut arena).unwrap();
+    /// n1.append(n1_3, &mut arena);
     ///
     /// // arena
     /// // `-- 1
@@ -528,7 +528,33 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_3));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn append<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Result<(), NodeError> {
+    pub fn append<T>(self, new_child: NodeId, arena: &mut Arena<T>) {
+        self.checked_append(new_child, arena)
+            .expect("Preconditions not met: `self != new_child` should hold but not");
+    }
+
+    /// Appends a new child to this node, after existing children.
+    ///
+    /// # Failures
+    ///
+    /// Returns an error if the given new child is `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// assert!(n1.checked_append(n1, &mut arena).is_err());
+    ///
+    /// let n1_1 = arena.new_node("1_1");
+    /// assert!(n1.checked_append(n1_1, &mut arena).is_ok());
+    /// ```
+    pub fn checked_append<T>(
+        self,
+        new_child: NodeId,
+        arena: &mut Arena<T>,
+    ) -> Result<(), NodeError> {
         if new_child == self {
             return Err(NodeError::AppendSelf);
         }
@@ -541,7 +567,7 @@ impl NodeId {
 
     /// Prepends a new child to this node, before existing children.
     ///
-    /// # Failures
+    /// # Panics
     ///
     /// Returns an error if the given new child is `self`.
     ///
@@ -552,11 +578,11 @@ impl NodeId {
     /// let mut arena = Arena::new();
     /// let n1 = arena.new_node("1");
     /// let n1_1 = arena.new_node("1_1");
-    /// n1.prepend(n1_1, &mut arena).unwrap();
+    /// n1.prepend(n1_1, &mut arena);
     /// let n1_2 = arena.new_node("1_2");
-    /// n1.prepend(n1_2, &mut arena).unwrap();
+    /// n1.prepend(n1_2, &mut arena);
     /// let n1_3 = arena.new_node("1_3");
-    /// n1.prepend(n1_3, &mut arena).unwrap();
+    /// n1.prepend(n1_3, &mut arena);
     ///
     /// // arena
     /// // `-- 1
@@ -571,7 +597,33 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_1));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn prepend<T>(self, new_child: NodeId, arena: &mut Arena<T>) -> Result<(), NodeError> {
+    pub fn prepend<T>(self, new_child: NodeId, arena: &mut Arena<T>) {
+        self.checked_prepend(new_child, arena)
+            .expect("Preconditions not met: `self != new_child` should hold but not");
+    }
+
+    /// Prepends a new child to this node, before existing children.
+    ///
+    /// # Failures
+    ///
+    /// Returns an error if the given new child is `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// assert!(n1.checked_prepend(n1, &mut arena).is_err());
+    ///
+    /// let n1_1 = arena.new_node("1_1");
+    /// assert!(n1.checked_prepend(n1_1, &mut arena).is_ok());
+    /// ```
+    pub fn checked_prepend<T>(
+        self,
+        new_child: NodeId,
+        arena: &mut Arena<T>,
+    ) -> Result<(), NodeError> {
         if new_child == self {
             return Err(NodeError::PrependSelf);
         }
@@ -583,7 +635,7 @@ impl NodeId {
 
     /// Inserts a new sibling after this node.
     ///
-    /// # Failures
+    /// # Panics
     ///
     /// Returns an error if the given new sibling is `self`.
     ///
@@ -591,20 +643,20 @@ impl NodeId {
     ///
     /// ```
     /// # use indextree::Arena;
-    /// let mut arena = Arena::new();
-    /// let n1 = arena.new_node("1");
-    /// let n1_1 = arena.new_node("1_1");
-    /// n1.append(n1_1, &mut arena).unwrap();
-    /// let n1_2 = arena.new_node("1_2");
-    /// n1.append(n1_2, &mut arena).unwrap();
-    ///
+    /// # let mut arena = Arena::new();
+    /// # let n1 = arena.new_node("1");
+    /// # let n1_1 = arena.new_node("1_1");
+    /// # n1.append(n1_1, &mut arena);
+    /// # let n1_2 = arena.new_node("1_2");
+    /// # n1.append(n1_2, &mut arena);
+    /// #
     /// // arena
     /// // `-- 1
     /// //     |-- 1_1
     /// //     `-- 1_2
     ///
     /// let n1_3 = arena.new_node("1_3");
-    /// n1_1.insert_after(n1_3, &mut arena).unwrap();
+    /// n1_1.insert_after(n1_3, &mut arena);
     ///
     /// // arena
     /// // `-- 1
@@ -619,7 +671,29 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_2));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn insert_after<T>(
+    pub fn insert_after<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) {
+        self.checked_insert_after(new_sibling, arena)
+            .expect("Preconditions not met: `self != new_sibling` should hold but not");
+    }
+
+    /// Inserts a new sibling after this node.
+    ///
+    /// # Failures
+    ///
+    /// Returns an error if the given new sibling is `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// assert!(n1.checked_insert_after(n1, &mut arena).is_err());
+    ///
+    /// let n2 = arena.new_node("2");
+    /// assert!(n1.checked_insert_after(n2, &mut arena).is_ok());
+    /// ```
+    pub fn checked_insert_after<T>(
         self,
         new_sibling: NodeId,
         arena: &mut Arena<T>,
@@ -651,9 +725,9 @@ impl NodeId {
     /// let mut arena = Arena::new();
     /// let n1 = arena.new_node("1");
     /// let n1_1 = arena.new_node("1_1");
-    /// n1.append(n1_1, &mut arena).unwrap();
+    /// n1.append(n1_1, &mut arena);
     /// let n1_2 = arena.new_node("1_2");
-    /// n1.append(n1_2, &mut arena).unwrap();
+    /// n1.append(n1_2, &mut arena);
     ///
     /// // arena
     /// // `-- 1
@@ -661,7 +735,7 @@ impl NodeId {
     /// //     `-- 1_2
     ///
     /// let n1_3 = arena.new_node("1_3");
-    /// n1_2.insert_before(n1_3, &mut arena).unwrap();
+    /// n1_2.insert_before(n1_3, &mut arena);
     ///
     /// // arena
     /// // `-- 1
@@ -676,7 +750,29 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_2));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn insert_before<T>(
+    pub fn insert_before<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) {
+        self.checked_insert_before(new_sibling, arena)
+            .expect("Preconditions not met: `self != new_sibling` should hold but not");
+    }
+
+    /// Inserts a new sibling before this node.
+    ///
+    /// # Failures
+    ///
+    /// Returns an error if the given new sibling is `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// assert!(n1.checked_insert_before(n1, &mut arena).is_err());
+    ///
+    /// let n2 = arena.new_node("2");
+    /// assert!(n1.checked_insert_before(n2, &mut arena).is_ok());
+    /// ```
+    pub fn checked_insert_before<T>(
         self,
         new_sibling: NodeId,
         arena: &mut Arena<T>,
@@ -713,15 +809,15 @@ impl NodeId {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_2_1 = arena.new_node("1_2_1");
-    /// # n1_2.append(n1_2_1, &mut arena).unwrap();
+    /// # n1_2.append(n1_2_1, &mut arena);
     /// # let n1_2_2 = arena.new_node("1_2_2");
-    /// # n1_2.append(n1_2_2, &mut arena).unwrap();
+    /// # n1_2.append(n1_2_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// #
     /// // arena
     /// // `-- 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! let b = arena.new_node(2);
 //!
 //! // Append b to a
-//! assert!(a.append(b, arena).is_ok());
+//! a.append(b, arena);
 //! assert_eq!(b.ancestors(arena).into_iter().count(), 2);
 //! ```
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -156,7 +156,7 @@ impl<T> Node<T> {
     /// assert_eq!(arena[n1].previous_sibling(), None);
     /// assert_eq!(arena[n2].previous_sibling(), None);
     ///
-    /// n1.insert_after(n2, &mut arena).unwrap();
+    /// n1.insert_after(n2, &mut arena);
     /// // arena
     /// // `-- (implicit)
     /// //     |-- 1
@@ -210,7 +210,7 @@ impl<T> Node<T> {
     /// assert_eq!(arena[n1].next_sibling(), None);
     /// assert_eq!(arena[n2].next_sibling(), None);
     ///
-    /// n1.insert_after(n2, &mut arena).unwrap();
+    /// n1.insert_after(n2, &mut arena);
     /// // arena
     /// // `-- (implicit)
     /// //     |-- 1
@@ -231,11 +231,11 @@ impl<T> Node<T> {
     /// # let mut arena = Arena::new();
     /// # let n1 = arena.new_node("1");
     /// # let n1_1 = arena.new_node("1_1");
-    /// # n1.append(n1_1, &mut arena).unwrap();
+    /// # n1.append(n1_1, &mut arena);
     /// # let n1_2 = arena.new_node("1_2");
-    /// # n1.append(n1_2, &mut arena).unwrap();
+    /// # n1.append(n1_2, &mut arena);
     /// # let n1_3 = arena.new_node("1_3");
-    /// # n1.append(n1_3, &mut arena).unwrap();
+    /// # n1.append(n1_3, &mut arena);
     /// // arena
     /// // `-- 1
     /// //     |-- 1_1

--- a/tests/insert-error.rs
+++ b/tests/insert-error.rs
@@ -6,26 +6,26 @@ use indextree::Arena;
 fn append_self() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
-    assert!(n1.append(n1, &mut arena).is_err());
+    assert!(n1.checked_append(n1, &mut arena).is_err());
 }
 
 #[test]
 fn prepend_self() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
-    assert!(n1.prepend(n1, &mut arena).is_err());
+    assert!(n1.checked_prepend(n1, &mut arena).is_err());
 }
 
 #[test]
 fn insert_after_self() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
-    assert!(n1.insert_after(n1, &mut arena).is_err());
+    assert!(n1.checked_insert_after(n1, &mut arena).is_err());
 }
 
 #[test]
 fn insert_before_self() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
-    assert!(n1.insert_before(n1, &mut arena).is_err());
+    assert!(n1.checked_insert_before(n1, &mut arena).is_err());
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -14,17 +14,17 @@ fn success_create() {
     };
 
     let a = new!(); // 1
-    assert!(a.append(new!(), arena).is_ok()); // 2
-    assert!(a.append(new!(), arena).is_ok()); // 3
-    assert!(a.prepend(new!(), arena).is_ok()); // 4
+    assert!(a.checked_append(new!(), arena).is_ok()); // 2
+    assert!(a.checked_append(new!(), arena).is_ok()); // 3
+    assert!(a.checked_prepend(new!(), arena).is_ok()); // 4
     let b = new!(); // 5
-    assert!(b.append(a, arena).is_ok());
-    assert!(a.insert_before(new!(), arena).is_ok()); // 6
-    assert!(a.insert_before(new!(), arena).is_ok()); // 7
-    assert!(a.insert_after(new!(), arena).is_ok()); // 8
-    assert!(a.insert_after(new!(), arena).is_ok()); // 9
+    assert!(b.checked_append(a, arena).is_ok());
+    assert!(a.checked_insert_before(new!(), arena).is_ok()); // 6
+    assert!(a.checked_insert_before(new!(), arena).is_ok()); // 7
+    assert!(a.checked_insert_after(new!(), arena).is_ok()); // 8
+    assert!(a.checked_insert_after(new!(), arena).is_ok()); // 9
     let c = new!(); // 10
-    assert!(b.append(c, arena).is_ok());
+    assert!(b.checked_append(c, arena).is_ok());
 
     arena[c].previous_sibling().unwrap().detach(arena);
 
@@ -42,7 +42,7 @@ fn first_prepend() {
     let arena = &mut Arena::new();
     let a = arena.new_node(1);
     let b = arena.new_node(2);
-    assert!(a.prepend(b, arena).is_ok());
+    assert!(a.checked_prepend(b, arena).is_ok());
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn success_detach() {
     let arena = &mut Arena::new();
     let a = arena.new_node(1);
     let b = arena.new_node(1);
-    assert!(a.append(b, arena).is_ok());
+    assert!(a.checked_append(b, arena).is_ok());
     assert_eq!(b.ancestors(arena).into_iter().count(), 2);
     b.detach(arena);
     assert_eq!(b.ancestors(arena).into_iter().count(), 1);
@@ -77,9 +77,9 @@ fn iter() {
     let b = arena.new_node(2);
     let c = arena.new_node(3);
     let d = arena.new_node(4);
-    assert!(a.append(b, arena).is_ok());
-    assert!(b.append(c, arena).is_ok());
-    assert!(a.append(d, arena).is_ok());
+    assert!(a.checked_append(b, arena).is_ok());
+    assert!(b.checked_append(c, arena).is_ok());
+    assert!(a.checked_append(d, arena).is_ok());
 
     let node_refs = arena.iter().collect::<Vec<_>>();
     assert_eq!(node_refs, vec![&arena[a], &arena[b], &arena[c], &arena[d]]);
@@ -93,9 +93,9 @@ fn par_iter() {
     let b = arena.new_node(2);
     let c = arena.new_node(3);
     let d = arena.new_node(4);
-    assert!(a.append(b, arena).is_ok());
-    assert!(b.append(c, arena).is_ok());
-    assert!(a.append(d, arena).is_ok());
+    assert!(a.checked_append(b, arena).is_ok());
+    assert!(b.checked_append(c, arena).is_ok());
+    assert!(a.checked_append(d, arena).is_ok());
 
     let node_refs = arena.par_iter().collect::<Vec<_>>();
     assert_eq!(node_refs, vec![&arena[a], &arena[b], &arena[c], &arena[d]]);
@@ -111,13 +111,13 @@ fn remove() {
     let n4 = arena.new_node(4);
     let n5 = arena.new_node(5);
     let n6 = arena.new_node(6);
-    assert!(n0.append(n1, arena).is_ok());
-    assert!(n0.append(n2, arena).is_ok());
-    assert!(n0.append(n3, arena).is_ok());
-    assert!(n2.append(n4, arena).is_ok());
-    assert!(n2.append(n5, arena).is_ok());
-    assert!(n2.append(n5, arena).is_ok());
-    assert!(n2.append(n6, arena).is_ok());
+    assert!(n0.checked_append(n1, arena).is_ok());
+    assert!(n0.checked_append(n2, arena).is_ok());
+    assert!(n0.checked_append(n3, arena).is_ok());
+    assert!(n2.checked_append(n4, arena).is_ok());
+    assert!(n2.checked_append(n5, arena).is_ok());
+    assert!(n2.checked_append(n5, arena).is_ok());
+    assert!(n2.checked_append(n6, arena).is_ok());
     n2.remove(arena);
 
     let node_refs = arena

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -17,7 +17,7 @@ fn toplevel_with_single_child() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
     let n1_1 = arena.new_node("1_1");
-    n1.append(n1_1, &mut arena).unwrap();
+    n1.append(n1_1, &mut arena);
     // arena
     // `-- 1 *
     //     `-- 1_1
@@ -36,9 +36,9 @@ fn toplevel_with_multiple_children() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
     let n1_1 = arena.new_node("1_1");
-    n1.append(n1_1, &mut arena).unwrap();
+    n1.append(n1_1, &mut arena);
     let n1_2 = arena.new_node("1_2");
-    n1.append(n1_2, &mut arena).unwrap();
+    n1.append(n1_2, &mut arena);
     // arena
     // `-- 1 *
     //     |-- 1_1
@@ -71,7 +71,7 @@ fn single_child_with_no_children() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
     let n1_1 = arena.new_node("1_1");
-    n1.append(n1_1, &mut arena).unwrap();
+    n1.append(n1_1, &mut arena);
     // arena
     // `-- 1
     //     `-- 1_1 *
@@ -94,9 +94,9 @@ fn single_child_with_single_child() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
     let n1_1 = arena.new_node("1_1");
-    n1.append(n1_1, &mut arena).unwrap();
+    n1.append(n1_1, &mut arena);
     let n1_1_1 = arena.new_node("1_1_1");
-    n1_1.append(n1_1_1, &mut arena).unwrap();
+    n1_1.append(n1_1_1, &mut arena);
     // arena
     // `-- 1
     //     `-- 1_1 *
@@ -130,11 +130,11 @@ fn first_child_with_no_children() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
     let n1_1 = arena.new_node("1_1");
-    n1.append(n1_1, &mut arena).unwrap();
+    n1.append(n1_1, &mut arena);
     let n1_2 = arena.new_node("1_2");
-    n1.append(n1_2, &mut arena).unwrap();
+    n1.append(n1_2, &mut arena);
     let n1_3 = arena.new_node("1_3");
-    n1.append(n1_3, &mut arena).unwrap();
+    n1.append(n1_3, &mut arena);
     // arena
     // `-- 1
     //     |-- 1_1 *
@@ -176,11 +176,11 @@ fn middle_child_with_no_children() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
     let n1_1 = arena.new_node("1_1");
-    n1.append(n1_1, &mut arena).unwrap();
+    n1.append(n1_1, &mut arena);
     let n1_2 = arena.new_node("1_2");
-    n1.append(n1_2, &mut arena).unwrap();
+    n1.append(n1_2, &mut arena);
     let n1_3 = arena.new_node("1_3");
-    n1.append(n1_3, &mut arena).unwrap();
+    n1.append(n1_3, &mut arena);
     // arena
     // `-- 1
     //     |-- 1_1
@@ -222,11 +222,11 @@ fn last_child_with_no_children() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
     let n1_1 = arena.new_node("1_1");
-    n1.append(n1_1, &mut arena).unwrap();
+    n1.append(n1_1, &mut arena);
     let n1_2 = arena.new_node("1_2");
-    n1.append(n1_2, &mut arena).unwrap();
+    n1.append(n1_2, &mut arena);
     let n1_3 = arena.new_node("1_3");
-    n1.append(n1_3, &mut arena).unwrap();
+    n1.append(n1_3, &mut arena);
     // arena
     // `-- 1
     //     |-- 1_1
@@ -268,13 +268,13 @@ fn middle_child_with_single_child() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
     let n1_1 = arena.new_node("1_1");
-    n1.append(n1_1, &mut arena).unwrap();
+    n1.append(n1_1, &mut arena);
     let n1_2 = arena.new_node("1_2");
-    n1.append(n1_2, &mut arena).unwrap();
+    n1.append(n1_2, &mut arena);
     let n1_2_1 = arena.new_node("1_2_1");
-    n1_2.append(n1_2_1, &mut arena).unwrap();
+    n1_2.append(n1_2_1, &mut arena);
     let n1_3 = arena.new_node("1_3");
-    n1.append(n1_3, &mut arena).unwrap();
+    n1.append(n1_3, &mut arena);
     // arena
     // `-- 1
     //     |-- 1_1
@@ -322,17 +322,17 @@ fn middle_child_with_multiple_children() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");
     let n1_1 = arena.new_node("1_1");
-    n1.append(n1_1, &mut arena).unwrap();
+    n1.append(n1_1, &mut arena);
     let n1_2 = arena.new_node("1_2");
-    n1.append(n1_2, &mut arena).unwrap();
+    n1.append(n1_2, &mut arena);
     let n1_2_1 = arena.new_node("1_2_1");
-    n1_2.append(n1_2_1, &mut arena).unwrap();
+    n1_2.append(n1_2_1, &mut arena);
     let n1_2_2 = arena.new_node("1_2_2");
-    n1_2.append(n1_2_2, &mut arena).unwrap();
+    n1_2.append(n1_2_2, &mut arena);
     let n1_2_3 = arena.new_node("1_2_3");
-    n1_2.append(n1_2_3, &mut arena).unwrap();
+    n1_2.append(n1_2_3, &mut arena);
     let n1_3 = arena.new_node("1_3");
-    n1.append(n1_3, &mut arena).unwrap();
+    n1.append(n1_3, &mut arena);
     // arena
     // `-- 1
     //     |-- 1_1


### PR DESCRIPTION
This is breaking change.
Closes #42.

This changes return types of node insertion methods and updates examples.

* `NodeId::{append,prepend,insert_after,insert_before}()` now return `()`, and panic when the preconditions are not met.
* `NodeId::checked_{append,prepend,insert_after,insert_before}()` is added.
  They return `Result<(), NodeError>` and return errors when the preconditions are not met.
  They are same as old insertion functions.
* Most of non-panicking examples are rewritten to use non-`checked` version for simplicity, instead of `.unwrap()` or `?`.