### PR TITLE
Forbid attaching removed node

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ pub enum NodeError {
     InsertBeforeSelf,
     /// Attempt to insert a node after itself.
     InsertAfterSelf,
+    /// Attempt to insert a removed node, or insert to a removed node.
+    Removed,
     // See <https://github.com/rust-lang/rfcs/blob/master/text/2008-non-exhaustive.md#how-we-do-this-today>.
     #[doc(hidden)]
     __Nonexhaustive,
@@ -29,6 +31,7 @@ impl NodeError {
             NodeError::PrependSelf => "Can not prepend a node to itself",
             NodeError::InsertBeforeSelf => "Can not insert a node before itself",
             NodeError::InsertAfterSelf => "Can not insert a node after itself",
+            NodeError::Removed => "Removed node cannot have any parent, siblings, and children",
             NodeError::__Nonexhaustive => panic!("`__Nonexhaustive` should not be used"),
         }
     }

--- a/src/relations.rs
+++ b/src/relations.rs
@@ -69,7 +69,10 @@ pub(crate) fn connect_neighbors<T>(
                 parent_node.first_child.is_some(),
                 parent_node.last_child.is_some()
             );
+            debug_assert!(!parent_node.is_removed());
         }
+        debug_assert!(!previous.map_or(false, |id| arena[id].is_removed()));
+        debug_assert!(!next.map_or(false, |id| arena[id].is_removed()));
     }
 
     let (mut parent_first_child, mut parent_last_child) = parent

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -142,3 +142,20 @@ fn remove() {
     assert_eq!(n3.preceding_siblings(arena).collect::<Vec<_>>().len(), 1);
     assert_eq!(n3.following_siblings(arena).collect::<Vec<_>>().len(), 1);
 }
+
+#[test]
+fn insert_removed_node() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n2 = arena.new_node("2");
+    n2.remove(&mut arena);
+
+    assert!(n1.checked_append(n2, &mut arena).is_err());
+    assert!(n2.checked_append(n1, &mut arena).is_err());
+    assert!(n1.checked_prepend(n2, &mut arena).is_err());
+    assert!(n2.checked_prepend(n1, &mut arena).is_err());
+    assert!(n1.checked_insert_after(n2, &mut arena).is_err());
+    assert!(n2.checked_insert_after(n1, &mut arena).is_err());
+    assert!(n1.checked_insert_before(n2, &mut arena).is_err());
+    assert!(n2.checked_insert_before(n1, &mut arena).is_err());
+}


### PR DESCRIPTION
Current implementation allows removed nodes to be attached to the tree again.

This change forbids the removed nodes to be attached to trees again.
Users can only see access the data part of the removed nodes, but should not manipulate the removed node itself.