### PR TITLE
Remove `NodeId::new()` and make `NodeId::from_non_zero_usize()` crate-local

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -118,9 +118,6 @@ impl<T> Arena<T> {
     /// let mut arena = Arena::new();
     /// let foo = arena.new_node("foo");
     /// assert_eq!(arena.get(foo).map(|node| node.data), Some("foo"));
-    ///
-    /// let ghost = NodeId::new(42);
-    /// assert!(arena.get(ghost).is_none());
     /// ```
     ///
     /// Note that this does not check whether the given node ID is created by
@@ -130,11 +127,13 @@ impl<T> Arena<T> {
     /// # use indextree::Arena;
     /// let mut arena = Arena::new();
     /// let foo = arena.new_node("foo");
+    /// let bar = arena.new_node("bar");
     /// assert_eq!(arena.get(foo).map(|node| node.data), Some("foo"));
     ///
     /// let mut another_arena = Arena::new();
     /// let _ = another_arena.new_node("Another arena");
     /// assert_eq!(another_arena.get(foo).map(|node| node.data), Some("Another arena"));
+    /// assert!(another_arena.get(bar).is_none());
     /// ```
     pub fn get(&self, id: NodeId) -> Option<&Node<T>> {
         self.nodes.get(id.index0())
@@ -152,9 +151,6 @@ impl<T> Arena<T> {
     /// let mut arena = Arena::new();
     /// let foo = arena.new_node("foo");
     /// assert_eq!(arena.get(foo).map(|node| node.data), Some("foo"));
-    ///
-    /// let ghost = NodeId::new(42);
-    /// assert!(arena.get_mut(ghost).is_none());
     ///
     /// arena.get_mut(foo).expect("The `foo` node exists").data = "FOO!";
     /// assert_eq!(arena.get(foo).map(|node| node.data), Some("FOO!"));

--- a/src/id.rs
+++ b/src/id.rs
@@ -42,52 +42,8 @@ impl NodeId {
         self.index1.get() - 1
     }
 
-    /// Creates a new `NodeId` from the given zero-based index.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is [`usize::max_value()`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use indextree::{Arena, NodeId};
-    /// let mut arena = Arena::new();
-    /// let foo = arena.new_node("foo");
-    /// let bar = arena.new_node("bar");
-    /// let baz = arena.new_node("baz");
-    ///
-    /// assert_eq!(NodeId::new(0), foo);
-    /// assert_eq!(NodeId::new(1), bar);
-    /// assert_eq!(NodeId::new(2), baz);
-    /// ```
-    ///
-    /// [`usize::max_value()`]:
-    /// https://doc.rust-lang.org/stable/std/primitive.usize.html#method.min_value
-    pub fn new(index0: usize) -> Self {
-        let index1 = NonZeroUsize::new(index0.wrapping_add(1))
-            .expect("Attempt to create `NodeId` from `usize::max_value()`");
-        NodeId { index1 }
-    }
-
     /// Creates a new `NodeId` from the given one-based index.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use std::num::NonZeroUsize;
-    /// # use indextree::{Arena, NodeId};
-    /// let mut arena = Arena::new();
-    /// let _foo = arena.new_node("foo");
-    /// let bar = arena.new_node("bar");
-    /// let _baz = arena.new_node("baz");
-    ///
-    /// let second_id = NonZeroUsize::new(2)
-    ///     .expect("Should success with non-zero integer");
-    /// let second = NodeId::from_non_zero_usize(second_id);
-    /// assert_eq!(second, bar);
-    /// ```
-    pub fn from_non_zero_usize(index1: NonZeroUsize) -> Self {
+    pub(crate) fn from_non_zero_usize(index1: NonZeroUsize) -> Self {
         NodeId { index1 }
     }
 


### PR DESCRIPTION
This is breaking change.

`NodeId` should not be crafted by the users.
Users should get correct `NodeId` from accessors and `Arena::new_node()`.
It is easy to store (since it implements `Copy` trait and has no lifetime restriction), and node access does not require direct integer index.

Additionally, users cannot get internal index from `NodeId` in usual way.
(They can guess the index, but it depends on hidden internal implementation, and it might be changed silently because it is hidden.)

`NodeId::new()` and `NodeId::from_non_zero_usize()` is useless for users.