### PR TITLE
Apply `cargo fix --edition-idioms`

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -196,7 +196,7 @@ impl<T> Arena<T> {
     /// ```
     ///
     /// [`is_removed()`]: struct.Node.html#method.is_removed
-    pub fn iter(&self) -> Iter<Node<T>> {
+    pub fn iter(&self) -> Iter<'_, Node<T>> {
         self.nodes.iter()
     }
 }
@@ -209,7 +209,7 @@ impl<T: Sync> Arena<T> {
     /// tested with the [`is_removed()`] method on the node.
     ///
     /// [`is_removed()`]: struct.Node.html#method.is_removed
-    pub fn par_iter(&self) -> rayon::slice::Iter<Node<T>> {
+    pub fn par_iter(&self) -> rayon::slice::Iter<'_, Node<T>> {
         self.nodes.par_iter()
     }
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -29,7 +29,7 @@ pub struct NodeId {
 }
 
 impl fmt::Display for NodeId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.index1)
     }
 }
@@ -129,7 +129,7 @@ impl NodeId {
     /// ```
     ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
-    pub fn ancestors<T>(self, arena: &Arena<T>) -> Ancestors<T> {
+    pub fn ancestors<T>(self, arena: &Arena<T>) -> Ancestors<'_, T> {
         Ancestors::new(arena, self)
     }
 
@@ -168,7 +168,7 @@ impl NodeId {
     /// ```
     ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
-    pub fn preceding_siblings<T>(self, arena: &Arena<T>) -> PrecedingSiblings<T> {
+    pub fn preceding_siblings<T>(self, arena: &Arena<T>) -> PrecedingSiblings<'_, T> {
         PrecedingSiblings::new(arena, self)
     }
 
@@ -207,7 +207,7 @@ impl NodeId {
     /// ```
     ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
-    pub fn following_siblings<T>(self, arena: &Arena<T>) -> FollowingSiblings<T> {
+    pub fn following_siblings<T>(self, arena: &Arena<T>) -> FollowingSiblings<'_, T> {
         FollowingSiblings::new(arena, self)
     }
 
@@ -241,7 +241,7 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_3));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn children<T>(self, arena: &Arena<T>) -> Children<T> {
+    pub fn children<T>(self, arena: &Arena<T>) -> Children<'_, T> {
         Children::new(arena, self)
     }
 
@@ -276,7 +276,7 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_1));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn reverse_children<T>(self, arena: &Arena<T>) -> ReverseChildren<T> {
+    pub fn reverse_children<T>(self, arena: &Arena<T>) -> ReverseChildren<'_, T> {
         ReverseChildren::new(arena, self)
     }
 
@@ -323,7 +323,7 @@ impl NodeId {
     /// ```
     ///
     /// [`skip`]: https://doc.rust-lang.org/stable/std/iter/trait.Iterator.html#method.skip
-    pub fn descendants<T>(self, arena: &Arena<T>) -> Descendants<T> {
+    pub fn descendants<T>(self, arena: &Arena<T>) -> Descendants<'_, T> {
         Descendants::new(arena, self)
     }
 
@@ -365,7 +365,7 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(NodeEdge::End(n1)));
     /// assert_eq!(iter.next(), None);
     /// ```
-    pub fn traverse<T>(self, arena: &Arena<T>) -> Traverse<T> {
+    pub fn traverse<T>(self, arena: &Arena<T>) -> Traverse<'_, T> {
         Traverse::new(arena, self)
     }
 
@@ -433,7 +433,7 @@ impl NodeId {
     /// reverse.reverse();
     /// assert_eq!(traverse, reverse);
     /// ```
-    pub fn reverse_traverse<T>(self, arena: &Arena<T>) -> ReverseTraverse<T> {
+    pub fn reverse_traverse<T>(self, arena: &Arena<T>) -> ReverseTraverse<'_, T> {
         ReverseTraverse::new(arena, self)
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -267,7 +267,7 @@ impl<T> Node<T> {
 }
 
 impl<T> fmt::Display for Node<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(parent) = self.parent {
             write!(f, "parent: {}; ", parent)?;
         } else {

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -18,7 +18,7 @@ macro_rules! impl_node_iterator {
 
 #[derive(Clone)]
 /// An iterator of references to the ancestors a given node.
-pub struct Ancestors<'a, T: 'a> {
+pub struct Ancestors<'a, T> {
     arena: &'a Arena<T>,
     node: Option<NodeId>,
 }
@@ -35,7 +35,7 @@ impl<'a, T> Ancestors<'a, T> {
 
 #[derive(Clone)]
 /// An iterator of references to the siblings before a given node.
-pub struct PrecedingSiblings<'a, T: 'a> {
+pub struct PrecedingSiblings<'a, T> {
     arena: &'a Arena<T>,
     node: Option<NodeId>,
 }
@@ -52,7 +52,7 @@ impl<'a, T> PrecedingSiblings<'a, T> {
 
 #[derive(Clone)]
 /// An iterator of references to the siblings after a given node.
-pub struct FollowingSiblings<'a, T: 'a> {
+pub struct FollowingSiblings<'a, T> {
     arena: &'a Arena<T>,
     node: Option<NodeId>,
 }
@@ -69,7 +69,7 @@ impl<'a, T> FollowingSiblings<'a, T> {
 
 #[derive(Clone)]
 /// An iterator of references to the children of a given node.
-pub struct Children<'a, T: 'a> {
+pub struct Children<'a, T> {
     arena: &'a Arena<T>,
     node: Option<NodeId>,
 }
@@ -86,7 +86,7 @@ impl<'a, T> Children<'a, T> {
 
 #[derive(Clone)]
 /// An iterator of references to the children of a given node, in reverse order.
-pub struct ReverseChildren<'a, T: 'a> {
+pub struct ReverseChildren<'a, T> {
     arena: &'a Arena<T>,
     node: Option<NodeId>,
 }
@@ -103,7 +103,7 @@ impl<'a, T> ReverseChildren<'a, T> {
 
 #[derive(Clone)]
 /// An iterator of references to a given node and its descendants, in tree order.
-pub struct Descendants<'a, T: 'a>(Traverse<'a, T>);
+pub struct Descendants<'a, T>(Traverse<'a, T>);
 
 impl<'a, T> Descendants<'a, T> {
     pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
@@ -141,7 +141,7 @@ pub enum NodeEdge {
 #[derive(Clone)]
 /// An iterator of references to a given node and its descendants, in tree
 /// order.
-pub struct Traverse<'a, T: 'a> {
+pub struct Traverse<'a, T> {
     arena: &'a Arena<T>,
     root: NodeId,
     next: Option<NodeEdge>,
@@ -193,7 +193,7 @@ impl<'a, T> Iterator for Traverse<'a, T> {
 #[derive(Clone)]
 /// An iterator of references to a given node and its descendants, in reverse
 /// tree order.
-pub struct ReverseTraverse<'a, T: 'a> {
+pub struct ReverseTraverse<'a, T> {
     arena: &'a Arena<T>,
     root: NodeId,
     next: Option<NodeEdge>,


### PR DESCRIPTION
This command changes some old idioms into new recommended code.
See <https://github.com/rust-lang-nursery/rustfix>.