### PR TITLE
Hide `Node::data` field and export `Node::get{,_mut}()`

### DIFF
--- a/examples/parallel_iteration.rs
+++ b/examples/parallel_iteration.rs
@@ -17,6 +17,6 @@ pub fn main() {
     println!("Parallel iteration over arena tree");
     let _: Vec<f64> = arena
         .par_iter()
-        .map(|ref mut i| (i.data as f64).sqrt())
+        .map(|ref mut i| (*i.get() as f64).sqrt())
         .collect();
 }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -56,15 +56,7 @@ impl<T> Arena<T> {
     pub fn new_node(&mut self, data: T) -> NodeId {
         let next_index1 = NonZeroUsize::new(self.nodes.len().wrapping_add(1))
             .expect("Too many nodes in the arena");
-        self.nodes.push(Node {
-            parent: None,
-            first_child: None,
-            last_child: None,
-            previous_sibling: None,
-            next_sibling: None,
-            removed: false,
-            data,
-        });
+        self.nodes.push(Node::new(data));
         NodeId::from_non_zero_usize(next_index1)
     }
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -51,7 +51,7 @@ impl<T> Arena<T> {
     /// let mut arena = Arena::new();
     /// let foo = arena.new_node("foo");
     ///
-    /// assert_eq!(arena[foo].data, "foo");
+    /// assert_eq!(*arena[foo].get(), "foo");
     /// ```
     pub fn new_node(&mut self, data: T) -> NodeId {
         let next_index1 = NonZeroUsize::new(self.nodes.len().wrapping_add(1))
@@ -115,7 +115,7 @@ impl<T> Arena<T> {
     /// # use indextree::{Arena, NodeId};
     /// let mut arena = Arena::new();
     /// let foo = arena.new_node("foo");
-    /// assert_eq!(arena.get(foo).map(|node| node.data), Some("foo"));
+    /// assert_eq!(arena.get(foo).map(|node| *node.get()), Some("foo"));
     /// ```
     ///
     /// Note that this does not check whether the given node ID is created by
@@ -126,11 +126,11 @@ impl<T> Arena<T> {
     /// let mut arena = Arena::new();
     /// let foo = arena.new_node("foo");
     /// let bar = arena.new_node("bar");
-    /// assert_eq!(arena.get(foo).map(|node| node.data), Some("foo"));
+    /// assert_eq!(arena.get(foo).map(|node| *node.get()), Some("foo"));
     ///
     /// let mut another_arena = Arena::new();
     /// let _ = another_arena.new_node("Another arena");
-    /// assert_eq!(another_arena.get(foo).map(|node| node.data), Some("Another arena"));
+    /// assert_eq!(another_arena.get(foo).map(|node| *node.get()), Some("Another arena"));
     /// assert!(another_arena.get(bar).is_none());
     /// ```
     pub fn get(&self, id: NodeId) -> Option<&Node<T>> {
@@ -148,10 +148,10 @@ impl<T> Arena<T> {
     /// # use indextree::{Arena, NodeId};
     /// let mut arena = Arena::new();
     /// let foo = arena.new_node("foo");
-    /// assert_eq!(arena.get(foo).map(|node| node.data), Some("foo"));
+    /// assert_eq!(arena.get(foo).map(|node| *node.get()), Some("foo"));
     ///
-    /// arena.get_mut(foo).expect("The `foo` node exists").data = "FOO!";
-    /// assert_eq!(arena.get(foo).map(|node| node.data), Some("FOO!"));
+    /// *arena.get_mut(foo).expect("The `foo` node exists").get_mut() = "FOO!";
+    /// assert_eq!(arena.get(foo).map(|node| *node.get()), Some("FOO!"));
     /// ```
     pub fn get_mut(&mut self, id: NodeId) -> Option<&mut Node<T>> {
         self.nodes.get_mut(id.index0())
@@ -171,9 +171,9 @@ impl<T> Arena<T> {
     /// let _bar = arena.new_node("bar");
     ///
     /// let mut iter = arena.iter();
-    /// assert_eq!(iter.next().map(|node| node.data), Some("foo"));
-    /// assert_eq!(iter.next().map(|node| node.data), Some("bar"));
-    /// assert_eq!(iter.next().map(|node| node.data), None);
+    /// assert_eq!(iter.next().map(|node| *node.get()), Some("foo"));
+    /// assert_eq!(iter.next().map(|node| *node.get()), Some("bar"));
+    /// assert_eq!(iter.next().map(|node| *node.get()), None);
     /// ```
     ///
     /// ```
@@ -184,9 +184,9 @@ impl<T> Arena<T> {
     /// bar.remove(&mut arena);
     ///
     /// let mut iter = arena.iter();
-    /// assert_eq!(iter.next().map(|node| (node.data, node.is_removed())), Some(("foo", false)));
-    /// assert_eq!(iter.next().map(|node| (node.data, node.is_removed())), Some(("bar", true)));
-    /// assert_eq!(iter.next().map(|node| (node.data, node.is_removed())), None);
+    /// assert_eq!(iter.next().map(|node| (*node.get(), node.is_removed())), Some(("foo", false)));
+    /// assert_eq!(iter.next().map(|node| (*node.get(), node.is_removed())), Some(("bar", true)));
+    /// assert_eq!(iter.next().map(|node| (*node.get(), node.is_removed())), None);
     /// ```
     ///
     /// [`is_removed()`]: struct.Node.html#method.is_removed

--- a/src/node.rs
+++ b/src/node.rs
@@ -23,12 +23,21 @@ pub struct Node<T> {
     pub(crate) first_child: Option<NodeId>,
     pub(crate) last_child: Option<NodeId>,
     pub(crate) removed: bool,
-
     /// The actual data which will be stored within the tree.
-    pub data: T,
+    pub(crate) data: T,
 }
 
 impl<T> Node<T> {
+    /// Returns a reference to the node data.
+    pub fn get(&self) -> &T {
+        &self.data
+    }
+
+    /// Returns a mutable reference to the node data.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.data
+    }
+
     /// Returns the ID of the parent node, unless this node is the root of the
     /// tree.
     ///

--- a/src/node.rs
+++ b/src/node.rs
@@ -38,6 +38,19 @@ impl<T> Node<T> {
         &mut self.data
     }
 
+    /// Creates a new `Node` with the default state and the given data.
+    pub(crate) fn new(data: T) -> Self {
+        Self {
+            parent: None,
+            previous_sibling: None,
+            next_sibling: None,
+            first_child: None,
+            last_child: None,
+            removed: false,
+            data,
+        }
+    }
+
     /// Returns the ID of the parent node, unless this node is the root of the
     /// tree.
     ///

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -30,7 +30,7 @@ fn success_create() {
 
     assert_eq!(
         b.descendants(arena)
-            .map(|node| arena[node].data)
+            .map(|node| *arena[node].get())
             .collect::<Vec<_>>(),
         [5, 6, 7, 1, 4, 2, 3, 9, 10]
     );
@@ -60,14 +60,14 @@ fn success_detach() {
 fn get() {
     let arena = &mut Arena::new();
     let id = arena.new_node(1);
-    assert_eq!(arena.get(id).unwrap().data, 1);
+    assert_eq!(*arena.get(id).unwrap().get(), 1);
 }
 
 #[test]
 fn get_mut() {
     let arena = &mut Arena::new();
     let id = arena.new_node(1);
-    assert_eq!(arena.get_mut(id).unwrap().data, 1);
+    assert_eq!(*arena.get_mut(id).unwrap().get(), 1);
 }
 
 #[test]
@@ -122,7 +122,13 @@ fn remove() {
 
     let node_refs = arena
         .iter()
-        .filter_map(|x| if !x.is_removed() { Some(x.data) } else { None })
+        .filter_map(|x| {
+            if !x.is_removed() {
+                Some(*x.get())
+            } else {
+                None
+            }
+        })
         .collect::<Vec<_>>();
     assert_eq!(node_refs, vec![0, 1, 3, 4, 5, 6]);
     assert_eq!(n2.children(arena).collect::<Vec<_>>().len(), 0);
@@ -134,7 +140,13 @@ fn remove() {
 
     let node_refs = arena
         .iter()
-        .filter_map(|x| if !x.is_removed() { Some(x.data) } else { None })
+        .filter_map(|x| {
+            if !x.is_removed() {
+                Some(*x.get())
+            } else {
+                None
+            }
+        })
         .collect::<Vec<_>>();
     assert_eq!(node_refs, vec![0, 1, 4, 5, 6]);
     assert_eq!(n3.children(arena).collect::<Vec<_>>().len(), 0);


### PR DESCRIPTION
This is breaking change.

Currently `Node::data` field is public, but it is very strong restriction for internal representation of the node.
Instead, it may be better to export `Node::get() -> &T` and `Node::get_mut() -> &mut T`, and hide `Node::data` field.

See [Future proofing - Rust API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/future-proofing.html#structs-have-private-fields-c-struct-private).