### PR TITLE
Add lint to forbid use of `unsafe`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! a.append(b, arena);
 //! assert_eq!(b.ancestors(arena).into_iter().count(), 2);
 //! ```
-
+#![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
This crate is written in completely safe Rust and (currently) does not seem to require power of `unsafe`.

`#[forbid(unsafe_code)]` forbids `unsafe` code, so this prevents `unsafe` codes from being injected accidentally, and also may help external analyzers to make sure there are no `unsafe`.