### PR TITLE
Implement Into<usize> for NodeId

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -34,9 +34,15 @@ impl fmt::Display for NodeId {
     }
 }
 
+impl Into<NonZeroUsize> for NodeId {
+    fn into(self) -> NonZeroUsize {
+        self.index1
+    }
+}
+
 impl Into<usize> for NodeId {
     fn into(self) -> usize {
-        self.index0()
+        self.index1.get()
     }
 }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -34,6 +34,12 @@ impl fmt::Display for NodeId {
     }
 }
 
+impl Into<usize> for NodeId {
+    fn into(self) -> usize {
+        self.index0()
+    }
+}
+
 impl NodeId {
     /// Returns zero-based index.
     pub(crate) fn index0(self) -> usize {


### PR DESCRIPTION
Implements `Into<usize> for NodeId`. This implementation returns `index0()` since 0-based indexing is more conventional.

A more explicit alternative would be making `index0` public. This  would have the benefit of not being "less astonishing", since one might not expect `Into` returning a different value.

For background info, see [the related issue](https://github.com/saschagrunert/indextree/issues/57) 

