### PR TITLE
fix: fix `NodeId::is_removed`

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -94,7 +94,7 @@ impl NodeId {
 
     /// Return if the `Node` of NodeId point to is removed.
     pub fn is_removed<T>(self, arena: &Arena<T>) -> bool {
-        arena[self].stamp == self.stamp
+        arena[self].stamp != self.stamp
     }
 
     /// Returns an iterator of IDs of this node and its ancestors.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -156,6 +156,14 @@ fn remove() {
 }
 
 #[test]
+fn is_removed() {
+    let arena = &mut Arena::new();
+    let n0 = arena.new_node(0);
+    n0.remove(arena);
+    assert!(n0.is_removed(arena));
+}
+
+#[test]
 fn insert_removed_node() {
     let mut arena = Arena::new();
     let n1 = arena.new_node("1");


### PR DESCRIPTION
`is_removed` method of ` NodeId` is not correct. Could you bump a new version of this issue?