### PR TITLE
Avoid making ancestor-descendant cycle on `append` and `prepend`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,10 @@ pub enum NodeError {
     InsertAfterSelf,
     /// Attempt to insert a removed node, or insert to a removed node.
     Removed,
+    /// Attempt to append an ancestor node to a descendant.
+    AppendAncestor,
+    /// Attempt to prepend an ancestor node to a descendant.
+    PrependAncestor,
 }
 
 impl NodeError {
@@ -30,6 +34,8 @@ impl NodeError {
             NodeError::InsertBeforeSelf => "Can not insert a node before itself",
             NodeError::InsertAfterSelf => "Can not insert a node after itself",
             NodeError::Removed => "Removed node cannot have any parent, siblings, and children",
+            NodeError::AppendAncestor => "Can not append a node to its descendant",
+            NodeError::PrependAncestor => "Can not prepend a node to its descendant",
         }
     }
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -516,6 +516,7 @@ impl NodeId {
     /// Panics if:
     ///
     /// * the given new child is `self`, or
+    /// * the given new child is an ancestor of `self`, or
     /// * the current node or the given new child was already [`remove`]d.
     ///
     /// To check if the node is removed or not, use [`Node::is_removed()`].
@@ -560,6 +561,8 @@ impl NodeId {
     ///
     /// * Returns [`NodeError::AppendSelf`] error if the given new child is
     ///   `self`.
+    /// * Returns [`NodeError::AppendAncestor`] error if the given new child is
+    ///   an ancestor of `self`.
     /// * Returns [`NodeError::Removed`] error if the given new child or `self`
     ///   is [`remove`]d.
     ///
@@ -592,6 +595,9 @@ impl NodeId {
         if arena[self].is_removed() || arena[new_child].is_removed() {
             return Err(NodeError::Removed);
         }
+        if self.ancestors(arena).any(|ancestor| new_child == ancestor) {
+            return Err(NodeError::AppendAncestor);
+        }
         new_child.detach(arena);
         insert_with_neighbors(arena, new_child, Some(self), arena[self].last_child, None)
             .expect("Should never fail: `new_child` is not `self` and they are not removed");
@@ -606,6 +612,7 @@ impl NodeId {
     /// Panics if:
     ///
     /// * the given new child is `self`, or
+    /// * the given new child is an ancestor of `self`, or
     /// * the current node or the given new child was already [`remove`]d.
     ///
     /// To check if the node is removed or not, use [`Node::is_removed()`].
@@ -650,6 +657,8 @@ impl NodeId {
     ///
     /// * Returns [`NodeError::PrependSelf`] error if the given new child is
     ///   `self`.
+    /// * Returns [`NodeError::PrependAncestor`] error if the given new child is
+    ///   an ancestor of `self`.
     /// * Returns [`NodeError::Removed`] error if the given new child or `self`
     ///   is [`remove`]d.
     ///
@@ -681,6 +690,9 @@ impl NodeId {
         }
         if arena[self].is_removed() || arena[new_child].is_removed() {
             return Err(NodeError::Removed);
+        }
+        if self.ancestors(arena).any(|ancestor| new_child == ancestor) {
+            return Err(NodeError::PrependAncestor);
         }
         insert_with_neighbors(arena, new_child, Some(self), None, arena[self].first_child)
             .expect("Should never fail: `new_child` is not `self` and they are not removed");

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,4 @@
-use indextree::Arena;
+use indextree::{Arena, NodeError};
 #[cfg(feature = "par_iter")]
 use rayon::prelude::*;
 
@@ -195,4 +195,48 @@ fn retrieve_node_id() {
     assert_eq!(retrieved_n1_id, n1_id);
     assert_eq!(retrieved_n2_id, n2_id);
     assert_eq!(retrieved_n3_id, n3_id);
+}
+
+#[test]
+// Issue #78.
+fn append_ancestor() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = arena.new_node("child");
+    root.append(child, &mut arena);
+    let grandchild = arena.new_node("grandchild");
+    child.append(grandchild, &mut arena);
+    // root
+    // `-- child
+    //     `-- grandchild
+    assert!(matches!(
+        grandchild.checked_append(root, &mut arena),
+        Err(NodeError::AppendAncestor)
+    ));
+    assert!(matches!(
+        grandchild.checked_append(child, &mut arena),
+        Err(NodeError::AppendAncestor)
+    ));
+}
+
+#[test]
+// Issue #78.
+fn prepend_ancestor() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = arena.new_node("child");
+    root.append(child, &mut arena);
+    let grandchild = arena.new_node("grandchild");
+    child.append(grandchild, &mut arena);
+    // root
+    // `-- child
+    //     `-- grandchild
+    assert!(matches!(
+        grandchild.checked_prepend(root, &mut arena),
+        Err(NodeError::PrependAncestor)
+    ));
+    assert!(matches!(
+        grandchild.checked_prepend(child, &mut arena),
+        Err(NodeError::PrependAncestor)
+    ));
 }


### PR DESCRIPTION
Fixes #78.

Unfortunately this makes `prepend` and `append` not constant time operation (worst `O(N)`), but I think this is necessary.

This change adds two new `NodeError` variants, but `NodeError` is marked `#[non_exhaustive]` so this is a feature addition but won't be a breaking change.