### PR TITLE
Suppress clippy lints by fixing the sources

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -48,14 +48,9 @@ impl<T> Arena<T> {
         T: PartialEq,
     {
         if let Some(node_id) = self.nodes.iter().position(|n| n.data == node.data) {
-            if let Some(node_id_non_zero) = NonZeroUsize::new(node_id.wrapping_add(1)) {
-                Some(NodeId::from_non_zero_usize(
-                    node_id_non_zero,
-                    self.nodes[node_id].stamp,
-                ))
-            } else {
-                None
-            }
+            NonZeroUsize::new(node_id.wrapping_add(1)).map(|node_id_non_zero| {
+                NodeId::from_non_zero_usize(node_id_non_zero, self.nodes[node_id].stamp)
+            })
         } else {
             None
         }

--- a/src/id.rs
+++ b/src/id.rs
@@ -1020,7 +1020,7 @@ impl NodeId {
             arena.free_node(id);
             let node = &arena[id];
             cursor = node.first_child.or(node.next_sibling).or_else(|| {
-                id.ancestors(&arena) // traverse ancestors upwards
+                id.ancestors(arena) // traverse ancestors upwards
                     .skip(1) // skip the starting node itself
                     .find(|n| arena[*n].next_sibling.is_some()) // first ancestor with a sibling
                     .and_then(|n| arena[n].next_sibling) // the sibling is the new cursor

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -11,7 +11,7 @@ fn success_create() {
             new_counter += 1;
             arena.new_node(new_counter)
         }};
-    };
+    }
 
     let a = new!(); // 1
     assert!(a.checked_append(new!(), arena).is_ok()); // 2
@@ -131,10 +131,10 @@ fn remove() {
         })
         .collect::<Vec<_>>();
     assert_eq!(node_refs, vec![0, 1, 3, 4, 5, 6]);
-    assert_eq!(n2.children(arena).collect::<Vec<_>>().len(), 0);
-    assert_eq!(n2.descendants(arena).collect::<Vec<_>>().len(), 1);
-    assert_eq!(n2.preceding_siblings(arena).collect::<Vec<_>>().len(), 1);
-    assert_eq!(n2.following_siblings(arena).collect::<Vec<_>>().len(), 1);
+    assert_eq!(n2.children(arena).count(), 0);
+    assert_eq!(n2.descendants(arena).count(), 1);
+    assert_eq!(n2.preceding_siblings(arena).count(), 1);
+    assert_eq!(n2.following_siblings(arena).count(), 1);
 
     n3.remove(arena);
 
@@ -149,10 +149,10 @@ fn remove() {
         })
         .collect::<Vec<_>>();
     assert_eq!(node_refs, vec![0, 1, 4, 5, 6]);
-    assert_eq!(n3.children(arena).collect::<Vec<_>>().len(), 0);
-    assert_eq!(n3.descendants(arena).collect::<Vec<_>>().len(), 1);
-    assert_eq!(n3.preceding_siblings(arena).collect::<Vec<_>>().len(), 1);
-    assert_eq!(n3.following_siblings(arena).collect::<Vec<_>>().len(), 1);
+    assert_eq!(n3.children(arena).count(), 0);
+    assert_eq!(n3.descendants(arena).count(), 1);
+    assert_eq!(n3.preceding_siblings(arena).count(), 1);
+    assert_eq!(n3.following_siblings(arena).count(), 1);
 }
 
 #[test]


### PR DESCRIPTION
Clippy version is `clippy 0.1.59 (9d1b210 2022-02-23)`.