### PR TITLE
Loosen trait bound for pretty printing

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -1138,10 +1138,7 @@ impl NodeId {
     /// ```
     #[inline]
     #[must_use]
-    pub fn debug_pretty_print<'a, T: fmt::Debug>(
-        &'a self,
-        arena: &'a Arena<T>,
-    ) -> DebugPrettyPrint<'a, T> {
+    pub fn debug_pretty_print<'a, T>(&'a self, arena: &'a Arena<T>) -> DebugPrettyPrint<'a, T> {
         DebugPrettyPrint::new(self, arena)
     }
 }

--- a/tests/debug_pretty_print.rs
+++ b/tests/debug_pretty_print.rs
@@ -199,3 +199,22 @@ fn display_alternate() {
     let (arena, root) = sample_tree();
     assert_eq!(format!("{:#}", root.debug_pretty_print(&arena)), EXPECTED);
 }
+
+#[test]
+fn non_debug_printable_type() {
+    #[derive(Clone)]
+    struct NonDebug(i32);
+    impl fmt::Display for NonDebug {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    let mut arena = Arena::new();
+    let root = arena.new_node(NonDebug(0));
+    let child = arena.new_node(NonDebug(1));
+    root.append(child, &mut arena);
+
+    const EXPECTED: &str = "0\n`-- 1";
+    assert_eq!(root.debug_pretty_print(&arena).to_string(), EXPECTED);
+}


### PR DESCRIPTION
`NodeId::debug_pretty_print()` introduced by #87 requires `T: Debug`, but it should be checked there since the value types such that `T: !Debug + Display` are also supported.
It is safe to remove the trait bound here since `impl<T: {Debug, Display}> {Debug, Display} for DebugPrettyPrint<'_, T>` requires necessary trait to be implemented.

This patch removes unnecessary trait bound from `NodeId::debug_pretty_print()`.