### PR TITLE
Add Predecessors Iterator and minor doc fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::{
     node::Node,
     traverse::{
         Ancestors, Children, Descendants, FollowingSiblings, NodeEdge, PrecedingSiblings,
-        ReverseChildren, ReverseTraverse, Traverse,
+        Predecessors, ReverseChildren, ReverseTraverse, Traverse,
     },
 };
 

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -19,7 +19,7 @@ macro_rules! impl_node_iterator {
 }
 
 #[derive(Clone)]
-/// An iterator of the IDs of the ancestors a given node.
+/// An iterator of the IDs of the ancestors of a given node.
 pub struct Ancestors<'a, T> {
     arena: &'a Arena<T>,
     node: Option<NodeId>,
@@ -27,6 +27,25 @@ pub struct Ancestors<'a, T> {
 impl_node_iterator!(Ancestors, |node: &Node<T>| node.parent);
 
 impl<'a, T> Ancestors<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
+        Self {
+            arena,
+            node: Some(current),
+        }
+    }
+}
+
+#[derive(Clone)]
+/// An iterator of the IDs of the predecessors of a given node.
+pub struct Predecessors<'a, T> {
+    arena: &'a Arena<T>,
+    node: Option<NodeId>,
+}
+impl_node_iterator!(Predecessors, |node: &Node<T>| {
+    node.previous_sibling.or(node.parent)
+});
+
+impl<'a, T> Predecessors<'a, T> {
     pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
         Self {
             arena,


### PR DESCRIPTION
Hi @saschagrunert and thanks for your great work on this crate!

I submit the attached contribution which contains 3 modifications:
* a convenience Iterator over Predecessors (including ancestors and previous siblings)
* a fix for a typo (missing "of") in Ancestor's documentation (line 22 of `src/traverse.rs`)
* some visual indices in Iterators' documentation which IMHO help legibility

Hope you'll find those useful.
And sorry I forgot to do multiple commits... feel free to discard what is unwanted

Cheers!