### PR TITLE
Remove broken badges.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,6 @@ description = "Arena based tree structure by using indices instead of reference 
 categories = ["data-structures"]
 edition = "2018"
 
-[badges]
-travis-ci = { repository = "saschagrunert/indextree", branch = "main" }
-appveyor = { repository = "saschagrunert/indextree", branch = "main", service = "github" }
-
 [features]
 default = ["std"]
 deser = [ "serde" ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # indextree
 
 [![GitHub Actions](https://github.com/saschagrunert/indextree/actions/workflows/test.yml/badge.svg)](https://github.com/saschagrunert/indextree/actions/workflows/test.yml)
-[![Build status](https://ci.appveyor.com/api/projects/status/byraapuh9py02us0?svg=true)](https://ci.appveyor.com/project/saschagrunert/indextree)
 [![Coverage](https://codecov.io/gh/saschagrunert/indextree/branch/main/graph/badge.svg)](https://codecov.io/gh/saschagrunert/indextree)
 [![Dependency Status](https://deps.rs/repo/github/saschagrunert/indextree/status.svg)](https://deps.rs/repo/github/saschagrunert/indextree)
 [![Doc indextree](https://img.shields.io/badge/main-indextree-blue.svg)](https://saschagrunert.github.io/indextree/doc/indextree)


### PR DESCRIPTION
* `README.md  no longer needs to link to appveyor.
* crates.io no longer supports CI badges via `Cargo.toml`: https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section