### PR TITLE
Add rkyv feature for zero-copy deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,14 @@ edition = "2018"
 [features]
 default = ["std"]
 deser = [ "serde" ]
+rkyv = [ "dep:rkyv" ]
 par_iter = ["rayon"]
 std = []
 
 [dependencies]
 rayon = { version = "1.7.0", optional = true }
 serde = { version = "1.0.154", features = ["derive"], optional = true }
+rkyv = { version = "0.7.44", optional = true }
 
 [[example]]
 name = "parallel_iteration"

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -15,6 +15,9 @@ use rayon::prelude::*;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "rkyv")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 #[cfg(feature = "std")]
 use std::{
     num::NonZeroUsize,
@@ -25,6 +28,7 @@ use crate::{node::NodeData, Node, NodeId};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
 /// An `Arena` structure containing certain [`Node`]s.
 ///
 /// [`Node`]: struct.Node.html

--- a/src/id.rs
+++ b/src/id.rs
@@ -6,6 +6,9 @@ use core::{fmt, num::NonZeroUsize};
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "rkyv")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 #[cfg(feature = "std")]
 use std::{fmt, num::NonZeroUsize};
 
@@ -19,6 +22,7 @@ use crate::{
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Debug, Hash)]
 #[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
 /// A node identifier within a particular [`Arena`].
 ///
 /// This ID is used to get [`Node`] references from an [`Arena`].
@@ -35,7 +39,8 @@ pub struct NodeId {
 /// is still the same node.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Debug, Hash, Default)]
 #[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
-pub(crate) struct NodeStamp(i16);
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+pub struct NodeStamp(i16);
 
 impl NodeStamp {
     pub fn is_removed(self) -> bool {

--- a/src/node.rs
+++ b/src/node.rs
@@ -6,6 +6,9 @@ use core::fmt;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "rkyv")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 #[cfg(feature = "std")]
 use std::fmt;
 
@@ -13,7 +16,8 @@ use crate::{id::NodeStamp, NodeId};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
-pub(crate) enum NodeData<T> {
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+pub enum NodeData<T> {
     /// The actual data store
     Data(T),
     /// The next free node position.
@@ -22,6 +26,7 @@ pub(crate) enum NodeData<T> {
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
 /// A node within a particular `Arena`.
 pub struct Node<T> {
     // Keep these private (with read-only accessors) so that we can keep them


### PR DESCRIPTION
Hi, thanks for this great crate.

I was dissatisfied with the deserialization performance of the `deser` feature (using serde and bincode) and looked into zero-copy alternatives. Using [rkyv](https://crates.io/crates/rkyv) I managed to read my Arena with ~17m nodes from disk in 3s (compared to 3min 30s before with serde).

This is a draft because I had to make a few types public, for it to compile. I would try to resolve that if you are generally interested in such a feature?