### PR TITLE
Implement `DoubleEndedIterator` for some iterator structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ homepage = "https://github.com/saschagrunert/indextree"
 documentation = "https://docs.rs/indextree"
 description = "Arena based tree structure by using indices instead of reference counted pointers"
 categories = ["data-structures"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["std"]
-deser = [ "serde" ]
+deser = ["serde"]
 par_iter = ["rayon"]
 std = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indextree"
-version = "4.6.1"
+version = "4.7.0"
 license = "MIT"
 readme = "README.md"
 keywords = ["tree", "arena", "index", "indextree", "trie"]

--- a/src/id.rs
+++ b/src/id.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "std")]
 use std::{fmt, num::NonZeroUsize};
 
+#[allow(deprecated)]
 use crate::{
     debug_pretty_print::DebugPrettyPrint,
     relations::{insert_last_unchecked, insert_with_neighbors},
@@ -361,6 +362,7 @@ impl NodeId {
     /// assert_eq!(iter.next(), Some(n1_1));                    // #3
     /// assert_eq!(iter.next(), None);
     /// ```
+    #[allow(deprecated)]
     pub fn reverse_children<T>(self, arena: &Arena<T>) -> ReverseChildren<'_, T> {
         ReverseChildren::new(arena, self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[allow(deprecated)]
 pub use crate::{
     arena::Arena,
     debug_pretty_print::DebugPrettyPrint,

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -158,7 +158,10 @@ new_iterator!(
 );
 
 new_iterator!(
-    #[deprecated(since = "4.7.0", note = "please, use Children::rev() instead if you want to iterate in reverse")]
+    #[deprecated(
+        since = "4.7.0",
+        note = "please, use Children::rev() instead if you want to iterate in reverse"
+    )]
     /// An iterator of the IDs of the children of a given node, in reverse insertion order.
     ReverseChildren,
     new = |arena, node| Iter::new(arena, arena[node].last_child, None),

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -45,6 +45,7 @@ macro_rules! new_iterator {
         #[derive(Clone)]
         pub struct $name<'a, T>($inner<'a, T>);
 
+        #[allow(deprecated)]
         impl<'a, T> $name<'a, T> {
             pub(crate) fn new(arena: &'a Arena<T>, node: NodeId) -> Self {
                 let new: fn(&'a Arena<T>, NodeId) -> $inner<'a, T> = $new;
@@ -73,6 +74,7 @@ macro_rules! new_iterator {
             }
         }
 
+        #[allow(deprecated)]
         impl<'a, T> core::iter::FusedIterator for $name<'a, T> {}
     };
     ($(#[$attr:meta])* $name:ident, new = $new:expr, next = $next:expr, next_back = $next_back:expr $(,)?) => {
@@ -106,6 +108,7 @@ macro_rules! new_iterator {
             }
         }
 
+        #[allow(deprecated)]
         impl<'a, T> ::core::iter::DoubleEndedIterator for $name<'a, T> {
             fn next_back(&mut self) -> Option<Self::Item> {
                 match (self.0.head, self.0.tail) {


### PR DESCRIPTION
> [!NOTE]\
> This PR is a semi-draft; I want to hear some feedback before I start refining the code.

Changes:
1. Implemented `DoubleEndedIterator` for some of the iterator structs
2. Reduced repetitiveness in `traverse.rs` using a new macro that replaces `impl_node_iterator!` completely
3. Removed `FusedIterator` for everything using the new macro, just to be safe (may be re-implemented if the current changes adhere to `FusedIterator`'s contract)
4. Deprecated `ReverseChildren` since `Children::rev()` is more idiomatic.

There is an edge-case for when I need to get first/last root node from the arena, in which case I resorted to `iter().next()` and `iter().last()`, which I don't think is efficient. If you have any suggestions, I'd be happy to hear them.