### PR TITLE
refactor(arena): use `slice::as_ptr_range` in `Arena::get_node_id`

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -5,6 +5,7 @@ use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))]
 use core::{
+    mem,
     num::NonZeroUsize,
     ops::{Index, IndexMut},
 };
@@ -17,6 +18,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use std::{
+    mem,
     num::NonZeroUsize,
     ops::{Index, IndexMut},
 };
@@ -86,12 +88,13 @@ impl<T> Arena<T> {
             return None;
         }
 
-        let node_index = (p as usize - nodes_range.start as usize) / core::mem::size_of::<Node<T>>();
-        let Some(node_id) = NonZeroUsize::new(node_index.wrapping_add(1)) else {
-            return None;
-        };
+        let node_index = (p as usize - nodes_range.start as usize) / mem::size_of::<Node<T>>();
+        let node_id = NonZeroUsize::new(node_index.wrapping_add(1))?;
 
-        Some(NodeId::from_non_zero_usize(node_id, self.nodes[node_index].stamp))
+        Some(NodeId::from_non_zero_usize(
+            node_id,
+            self.nodes[node_index].stamp,
+        ))
     }
 
     /// Retrieves the `NodeId` corresponding to the `Node` at `index` in the `Arena`, if it exists.


### PR DESCRIPTION
Found the comment and decided to refactor it ¯\\\_(ツ)\_/¯

I changed up the control flow a little in order to reduce nesting, and also renamed some of the variables for clarity (`node_id` -> `node_index`, `node_id_non_zero` -> `node_id`).