### PR TITLE
fix: reversing iterators only returns the last element on repeat

### DIFF
--- a/indextree/src/traverse.rs
+++ b/indextree/src/traverse.rs
@@ -121,7 +121,7 @@ macro_rules! new_iterator {
                     (None, Some(tail)) | (Some(_), Some(tail)) => {
                         let next_back: fn(&Node<T>) -> Option<NodeId> = $next_back;
 
-                        self.0.head = next_back(&self.0.arena[tail]);
+                        self.0.tail = next_back(&self.0.arena[tail]);
                         Some(tail)
                     }
                     (Some(_), None)| (None, None) => None,

--- a/indextree/tests/lib.rs
+++ b/indextree/tests/lib.rs
@@ -281,3 +281,17 @@ fn inaccessible_node() {
     assert_eq!(*arena[n1_id].get(), "1");
     n2_id.is_removed(&arena);
 }
+
+#[test]
+fn reverse_children() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(10);
+    root.append_value(1, &mut arena);
+    root.append_value(2, &mut arena);
+    root.append_value(3, &mut arena);
+    let mut iter = root.children(&arena).rev().map(|n| *arena[n].get());
+    assert_eq!(iter.next(), Some(3));
+    assert_eq!(iter.next(), Some(2));
+    assert_eq!(iter.next(), Some(1));
+    assert_eq!(iter.next(), None);
+}


### PR DESCRIPTION
I found this bug when I was working on [my WIP library](https://github.com/jroid8/math-eval) where most test failed
The breaking commit was [this one](https://github.com/Jroid8/math-eval/commit/906411d359220b3909fcb5d3c1af79b7ecb12a9f) which upgraded indextree to the latest version.
I included a small test to ensure the diff works, since that test and the tests in my library now both succeed I think the bug should be fixed.