### PR TITLE
Bump version to v4.8.1

### DIFF
--- a/indextree-macros/Cargo.toml
+++ b/indextree-macros/Cargo.toml
@@ -19,4 +19,4 @@ quote = "1.0.40"
 syn = { version = "2.0.101", features = ["full"] }
 
 [dev-dependencies]
-indextree = { path = "../indextree", version = "4.8.0" }
+indextree = { path = "../indextree", version = "4.8.1" }

--- a/indextree/Cargo.toml
+++ b/indextree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indextree"
-version = "4.8.0"
+version = "4.8.1"
 license = "MIT"
 readme = "../README.md"
 keywords = ["tree", "arena", "index", "indextree"]


### PR DESCRIPTION
- Bump indextree version from 4.8.0 to 4.8.1
- Update indextree dev-dependency in indextree-macros accordingly