### PR TITLE
Replace `unreachable!()` with `panic!()` on freed node

### DIFF
--- a/indextree/src/node.rs
+++ b/indextree/src/node.rs
@@ -42,20 +42,28 @@ pub struct Node<T> {
 
 impl<T> Node<T> {
     /// Returns a reference to the node data.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node has been removed.
     pub fn get(&self) -> &T {
         if let NodeData::Data(ref data) = self.data {
             data
         } else {
-            unreachable!("Try to access a freed node")
+            panic!("attempted to access a freed node")
         }
     }
 
     /// Returns a mutable reference to the node data.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node has been removed.
     pub fn get_mut(&mut self) -> &mut T {
         if let NodeData::Data(ref mut data) = self.data {
             data
         } else {
-            unreachable!("Try to access a freed node")
+            panic!("attempted to access a freed node")
         }
     }
 


### PR DESCRIPTION
This pull request replaces `unreachable!` with `panic!` when calling `get` on a freed node:

```rust
use indextree::Arena;

fn main() {
    let mut arena = Arena::new();

    let a = arena.new_node(1);
    a.remove(&mut arena);

    arena.get(a).is_some_and(|a| *a.get() == 0);
}
```

Currently, this results in the error `internal error: entered unreachable code: Try to access a freed node`.

[`unreachable!()`](https://doc.rust-lang.org/std/macro.unreachable.html) is the wrong thing to use here since it is intended to be used for when the compiler can't determine that some code is unreachable. When this is reached, it communicates to the user that there is a fatal bug in this crate (considering that there is also [`unreachable_unchecked!()`](https://doc.rust-lang.org/std/hint/fn.unreachable_unchecked.html) that would cause undefined behaviour if reached) rather than a user error.

In this case, a plain [`panic!()`](https://doc.rust-lang.org/core/macro.panic.html) is more suitable and since the function can panic due to user error, I've added a 'Panics' section to the function's rustdoc, as suggested in [How to write documentation](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html#documenting-components) and the [`missing_panics_doc`](https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#missing_panics_doc) clippy lint.

Panic messages in the standard library also aren't capitalised. E.g. `index out of bounds`.

With this pull request, the code results in the error `attempted to access a freed node`.