### PR TITLE
Improve correctness, API surface, and test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,23 @@ jobs:
           restore-keys: rust-msrv-
       - run: cargo test --all-features
 
+  discover-features:
+    runs-on: ubuntu-latest
+    outputs:
+      features: ${{ steps.features.outputs.features }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: features
+        run: |
+          features=$(awk '/^\[features\]/{f=1;next} /^\[/{f=0} f && /^[a-z_]+ =/ && !/^default / && !/^std /{print $1}' \
+            indextree/Cargo.toml | jq -Rsc 'split("\n") | map(select(length > 0)) | [""] + .')
+          echo "features=$features" >> "$GITHUB_OUTPUT"
+
   test-no-std:
+    needs: discover-features
+    strategy:
+      matrix:
+        features: ${{ fromJson(needs.discover-features.outputs.features) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -85,11 +101,49 @@ jobs:
           path: |
             target
             ~/.cargo/registry
-          key: rust-test-no-std-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: rust-test-no-std-
-      - run: cargo test --no-default-features
-      - run: cargo test --no-default-features --features deser
-      - run: cargo test --no-default-features --features macros
+          key: rust-test-no-std-${{ matrix.features }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-test-no-std-${{ matrix.features }}-
+      - run: cargo test --no-default-features ${{ matrix.features && format('--features {0}', matrix.features) }}
+
+  test-platform:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: stable
+      - run: cargo generate-lockfile
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target
+            ~/.cargo/registry
+          key: rust-test-platform-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-test-platform-${{ matrix.os }}-
+      - run: cargo test --all-features
+
+  nightly:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: nightly
+          components: clippy
+      - run: cargo generate-lockfile
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target
+            ~/.cargo/registry
+          key: rust-nightly-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-nightly-
+      - run: cargo test --all-features
+      - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ build-doc:
 
 lint-clippy:
 	cargo clippy --all-targets --all-features -- -D warnings
+	cargo clippy --all-targets --no-default-features -- -D warnings
 
 lint-rustfmt:
 	cargo fmt --version

--- a/README.md
+++ b/README.md
@@ -17,14 +17,20 @@ through unique (&mut) access to the arena. The tree can be sent or shared across
 threads like a `Vec`. This enables general multiprocessing support like
 parallel tree traversals.
 
+### Minimum Supported Rust Version (MSRV)
+
+The current MSRV is **1.85.0**.
+
 ### Features
 
 | Feature    | Default | Description                                                        |
 | ---------- | ------- | ------------------------------------------------------------------ |
 | `std`      | yes     | Standard library support. Disable for `no_std` (requires `alloc`). |
 | `macros`   | yes     | `tree!` macro for declarative tree construction.                   |
-| `deser`    | no      | Serde serialization and deserialization.                           |
+| `serde`    | no      | Serde serialization and deserialization.                           |
 | `par_iter` | no      | Parallel iteration via rayon.                                      |
+
+The legacy feature name `deser` is still accepted as an alias for `serde`.
 
 ### Example usage
 
@@ -109,4 +115,14 @@ for i in 1..=1000 {
 
 let sum: i64 = arena.par_iter().map(|node| *node.get()).sum();
 assert_eq!(sum, 500500);
+```
+
+### `no_std` usage
+
+Disable default features and the crate works in `no_std` environments
+(requires `alloc`):
+
+```toml
+[dependencies]
+indextree = { version = "4", default-features = false }
 ```

--- a/indextree-macros/src/lib.rs
+++ b/indextree-macros/src/lib.rs
@@ -17,12 +17,13 @@ impl Parse for IndexNode {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let node = input.parse::<Expr>()?;
 
-        if input.parse::<Token![=>]>().is_err() {
+        if !input.peek(Token![=]) || !input.peek2(Token![>]) {
             return Ok(IndexNode {
                 node,
                 children: Punctuated::new(),
             });
         }
+        input.parse::<Token![=>]>()?;
 
         let children_stream;
         braced!(children_stream in input);
@@ -47,7 +48,8 @@ impl Parse for IndexTree {
 
         let root_node = input.parse::<Expr>()?;
 
-        let nodes = if input.parse::<Token![=>]>().is_ok() {
+        let nodes = if input.peek(Token![=]) && input.peek2(Token![>]) {
+            input.parse::<Token![=>]>()?;
             let braced_nodes;
             braced!(braced_nodes in input);
             braced_nodes.parse_terminated(IndexNode::parse, Token![,])?
@@ -291,12 +293,16 @@ pub fn tree(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
         impl<__T> __NodeIdToNodeId<__T> for __Wrapping<::indextree::NodeId> {
             fn __to_node_id(&mut self, __arena: &mut ::indextree::Arena<__T>) -> ::indextree::NodeId {
+                // SAFETY: `take` is called exactly once per macro invocation;
+                // the `ManuallyDrop` wrapper is never read again afterwards.
                 unsafe { ::core::mem::ManuallyDrop::take(&mut self.0) }
             }
         }
 
         impl<__T> __ToNodeId<__T> for &mut __Wrapping<__T> {
             fn __to_node_id(&mut self, __arena: &mut ::indextree::Arena<__T>) -> ::indextree::NodeId {
+                // SAFETY: `take` is called exactly once per macro invocation;
+                // the `ManuallyDrop` wrapper is never read again afterwards.
                 ::indextree::Arena::new_node(__arena, unsafe { ::core::mem::ManuallyDrop::take(&mut self.0) })
             }
         }

--- a/indextree/Cargo.toml
+++ b/indextree/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.85.0"
 
 [features]
 default = ["std", "macros"]
+serde = ["dep:serde"]
 deser = ["serde"]
 par_iter = ["rayon"]
 std = []
@@ -24,6 +25,9 @@ macros = ["indextree-macros"]
 rayon = { version = "1.10.0", optional = true }
 serde = { version = "1.0.219", features = ["derive"], optional = true }
 indextree-macros = { path = "../indextree-macros", version = "0.1.3", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0.143"
 
 [[example]]
 name = "parallel_iteration"

--- a/indextree/src/arena.rs
+++ b/indextree/src/arena.rs
@@ -18,7 +18,7 @@ use core::{
 #[cfg(feature = "par_iter")]
 use rayon::prelude::*;
 
-#[cfg(feature = "deser")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -32,7 +32,7 @@ use std::{
 use crate::{Node, NodeId, node::NodeData};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
-#[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 /// An `Arena` structure containing certain [`Node`]s.
 pub struct Arena<T> {
     nodes: Vec<Node<T>>,
@@ -164,7 +164,7 @@ impl<T> Arena<T> {
         NodeId::from_non_zero_usize(next_index1, stamp)
     }
 
-    /// Returns the number of nodes in the arena, including removed nodes.
+    /// Returns the number of slots in the arena, including removed nodes.
     ///
     /// Removed nodes are still counted because they remain in the
     /// internal storage. Use [`iter()`] with [`Node::is_removed()`]
@@ -181,12 +181,22 @@ impl<T> Arena<T> {
     /// let foo = arena.new_node("foo");
     /// let _bar = arena.new_node("bar");
     /// assert_eq!(arena.count(), 2);
+    /// assert_eq!(arena.len(), 2);
     ///
     /// foo.remove(&mut arena);
     /// // The removed node is still counted.
     /// assert_eq!(arena.count(), 2);
+    /// assert_eq!(arena.len(), 2);
     /// ```
     pub fn count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Returns the number of slots in the arena, including removed nodes.
+    ///
+    /// This is an alias for [`count()`](Arena::count) following the Rust
+    /// naming convention for collection lengths.
+    pub fn len(&self) -> usize {
         self.nodes.len()
     }
 
@@ -211,7 +221,8 @@ impl<T> Arena<T> {
 
     /// Returns a reference to the node with the given id if in the arena.
     ///
-    /// Returns `None` if not available.
+    /// Returns `None` if the index is out of bounds or the node's stamp
+    /// does not match (i.e. the slot was removed and possibly reused).
     ///
     /// # Examples
     ///
@@ -222,29 +233,26 @@ impl<T> Arena<T> {
     /// assert_eq!(arena.get(foo).map(|node| *node.get()), Some("foo"));
     /// ```
     ///
-    /// Note that this does not check whether the given node ID is created by
-    /// the arena.
+    /// Stale `NodeId`s from removed nodes return `None`:
     ///
     /// ```
     /// # use indextree::Arena;
     /// let mut arena = Arena::new();
     /// let foo = arena.new_node("foo");
-    /// let bar = arena.new_node("bar");
-    /// assert_eq!(arena.get(foo).map(|node| *node.get()), Some("foo"));
-    ///
-    /// let mut another_arena = Arena::new();
-    /// let _ = another_arena.new_node("Another arena");
-    /// assert_eq!(another_arena.get(foo).map(|node| *node.get()), Some("Another arena"));
-    /// assert!(another_arena.get(bar).is_none());
+    /// foo.remove(&mut arena);
+    /// assert!(arena.get(foo).is_none());
     /// ```
     pub fn get(&self, id: NodeId) -> Option<&Node<T>> {
-        self.nodes.get(id.index0())
+        self.nodes
+            .get(id.index0())
+            .filter(|node| node.stamp == id.stamp())
     }
 
     /// Returns a mutable reference to the node with the given id if in the
     /// arena.
     ///
-    /// Returns `None` if not available.
+    /// Returns `None` if the index is out of bounds or the node's stamp
+    /// does not match.
     ///
     /// # Examples
     ///
@@ -258,7 +266,10 @@ impl<T> Arena<T> {
     /// assert_eq!(arena.get(foo).map(|node| *node.get()), Some("FOO!"));
     /// ```
     pub fn get_mut(&mut self, id: NodeId) -> Option<&mut Node<T>> {
-        self.nodes.get_mut(id.index0())
+        let stamp = id.stamp();
+        self.nodes
+            .get_mut(id.index0())
+            .filter(|node| node.stamp == stamp)
     }
 
     /// Returns an iterator of all nodes in the arena in storage-order.
@@ -358,14 +369,13 @@ impl<T> Arena<T> {
 
     /// Clears all the nodes in the arena, but retains its allocated capacity.
     ///
-    /// Note that this does not marks all nodes as removed, but completely
-    /// removes them from the arena storage, thus invalidating all the node ids
-    /// that were previously created.
+    /// Note that this does not mark all nodes as removed, but completely
+    /// removes them from the arena storage, thus invalidating all the node
+    /// IDs that were previously created.
     ///
-    /// Any attempt to call the [`is_removed()`] method on the node id will
-    /// result in panic behavior.
-    ///
-    /// [`is_removed()`]: NodeId::is_removed
+    /// After clearing, [`NodeId::is_removed`] returns `true` for any
+    /// previously created ID (without panicking), and [`Arena::get`]
+    /// returns `None`.
     pub fn clear(&mut self) {
         self.nodes.clear();
         self.first_free_slot = None;
@@ -384,8 +394,11 @@ impl<T> Arena<T> {
 
     pub(crate) fn free_node(&mut self, id: NodeId) {
         let node = &mut self[id];
+        if node.is_removed() {
+            return;
+        }
         node.data = NodeData::NextFree(None);
-        node.stamp.as_removed();
+        node.stamp.mark_removed();
         let stamp = node.stamp;
         if stamp.reuseable() {
             if let Some(index) = self.last_free_slot {
@@ -445,6 +458,60 @@ impl<T: Sync> Arena<T> {
     /// [`is_removed()`]: Node::is_removed
     pub fn par_iter(&self) -> rayon::slice::Iter<'_, Node<T>> {
         self.nodes.par_iter()
+    }
+}
+
+#[cfg(feature = "par_iter")]
+impl<T: Send> Arena<T> {
+    /// Returns a mutable parallel iterator over the whole arena.
+    ///
+    /// Requires the `par_iter` feature. Uses [rayon](https://docs.rs/rayon)
+    /// for data parallelism across all nodes in storage order.
+    ///
+    /// Note that this iterator returns also removed elements, which can be
+    /// tested with the [`is_removed()`] method on the node.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// # use rayon::prelude::*;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node(1);
+    /// root.append_value(2, &mut arena);
+    /// root.append_value(3, &mut arena);
+    ///
+    /// arena.par_iter_mut().for_each(|node| {
+    ///     if let Some(data) = node.try_get_mut() {
+    ///         *data *= 10;
+    ///     }
+    /// });
+    ///
+    /// let sum: i64 = arena.par_iter().map(|node| *node.get()).sum();
+    /// assert_eq!(sum, 60);
+    /// ```
+    ///
+    /// [`is_removed()`]: Node::is_removed
+    pub fn par_iter_mut(&mut self) -> rayon::slice::IterMut<'_, Node<T>> {
+        self.nodes.par_iter_mut()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Arena<T> {
+    type Item = &'a Node<T>;
+    type IntoIter = slice::Iter<'a, Node<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut Arena<T> {
+    type Item = &'a mut Node<T>;
+    type IntoIter = slice::IterMut<'a, Node<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
     }
 }
 

--- a/indextree/src/error.rs
+++ b/indextree/src/error.rs
@@ -33,7 +33,7 @@ use std::{error, fmt};
 ///     Err(NodeError::AppendAncestor)
 /// ));
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeError {
     /// Attempted to append a node to itself.
     AppendSelf,

--- a/indextree/src/id.rs
+++ b/indextree/src/id.rs
@@ -7,7 +7,7 @@
 #[cfg(not(feature = "std"))]
 use core::{fmt, num::NonZeroUsize};
 
-#[cfg(feature = "deser")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
@@ -22,7 +22,7 @@ use crate::{
 };
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Debug, Hash)]
-#[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 /// A node identifier within a particular [`Arena`].
 ///
 /// This ID is used to get [`Node`](crate::Node) references from an [`Arena`].
@@ -42,7 +42,7 @@ pub struct NodeId {
 /// 32,766 cycles the slot becomes permanently unreusable, preventing stamp
 /// value collisions.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Debug, Hash, Default)]
-#[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub(crate) struct NodeStamp(i16);
 
 impl NodeStamp {
@@ -56,7 +56,7 @@ impl NodeStamp {
     ///
     /// The resulting negative value differs from the live stamp, allowing
     /// `NodeId::is_removed` to detect stale references via inequality.
-    pub fn as_removed(&mut self) {
+    pub fn mark_removed(&mut self) {
         debug_assert!(!self.is_removed());
         self.0 = if self.0 < i16::MAX {
             -self.0 - 1
@@ -116,9 +116,23 @@ impl NodeId {
         NodeId { index1, stamp }
     }
 
-    /// Return if the `Node` of NodeId point to is removed.
+    /// Returns the stamp associated with this node ID.
+    pub(crate) fn stamp(self) -> NodeStamp {
+        self.stamp
+    }
+
+    /// Returns `true` if the node this ID points to has been removed or
+    /// is no longer present in the arena.
+    ///
+    /// Unlike indexing with `arena[id]`, this method does not panic when
+    /// the node ID is out of bounds (e.g. after [`Arena::clear`]).
+    ///
+    /// [`Arena::clear`]: crate::Arena::clear
     pub fn is_removed<T>(self, arena: &Arena<T>) -> bool {
-        arena[self].stamp != self.stamp
+        match arena.as_slice().get(self.index0()) {
+            Some(node) => node.stamp != self.stamp,
+            None => true,
+        }
     }
 
     /// Returns the ID of the parent node, unless this node is the root of the
@@ -407,6 +421,96 @@ impl NodeId {
     /// ```
     pub fn child_count<T>(self, arena: &Arena<T>) -> usize {
         self.children(arena).count()
+    }
+
+    /// Returns the depth (level) of this node in the tree.
+    ///
+    /// A root node (no parent) has depth 0, its children have depth 1, etc.
+    /// This traverses ancestors and is O(depth).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node("root");
+    /// let child = root.append_value("child", &mut arena);
+    /// let grandchild = child.append_value("grandchild", &mut arena);
+    ///
+    /// assert_eq!(root.depth(&arena), 0);
+    /// assert_eq!(child.depth(&arena), 1);
+    /// assert_eq!(grandchild.depth(&arena), 2);
+    /// ```
+    pub fn depth<T>(self, arena: &Arena<T>) -> usize {
+        self.ancestors(arena).count() - 1
+    }
+
+    /// Returns the nth child of this node (zero-indexed).
+    ///
+    /// Returns `None` if the node has fewer than `n + 1` children.
+    /// This is O(n) as it walks the sibling chain.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node("root");
+    /// let c0 = root.append_value("c0", &mut arena);
+    /// let c1 = root.append_value("c1", &mut arena);
+    /// let c2 = root.append_value("c2", &mut arena);
+    ///
+    /// assert_eq!(root.nth_child(0, &arena), Some(c0));
+    /// assert_eq!(root.nth_child(1, &arena), Some(c1));
+    /// assert_eq!(root.nth_child(2, &arena), Some(c2));
+    /// assert_eq!(root.nth_child(3, &arena), None);
+    /// ```
+    pub fn nth_child<T>(self, n: usize, arena: &Arena<T>) -> Option<NodeId> {
+        self.children(arena).nth(n)
+    }
+
+    /// Returns `true` if this node is an ancestor of `other`.
+    ///
+    /// A node is not considered an ancestor of itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node("root");
+    /// let child = root.append_value("child", &mut arena);
+    /// let grandchild = child.append_value("grandchild", &mut arena);
+    ///
+    /// assert!(root.is_ancestor_of(child, &arena));
+    /// assert!(root.is_ancestor_of(grandchild, &arena));
+    /// assert!(!child.is_ancestor_of(root, &arena));
+    /// assert!(!root.is_ancestor_of(root, &arena));
+    /// ```
+    pub fn is_ancestor_of<T>(self, other: NodeId, arena: &Arena<T>) -> bool {
+        other.ancestors(arena).skip(1).any(|a| a == self)
+    }
+
+    /// Returns `true` if this node is a descendant of `other`.
+    ///
+    /// A node is not considered a descendant of itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node("root");
+    /// let child = root.append_value("child", &mut arena);
+    /// let grandchild = child.append_value("grandchild", &mut arena);
+    ///
+    /// assert!(grandchild.is_descendant_of(root, &arena));
+    /// assert!(child.is_descendant_of(root, &arena));
+    /// assert!(!root.is_descendant_of(child, &arena));
+    /// assert!(!root.is_descendant_of(root, &arena));
+    /// ```
+    pub fn is_descendant_of<T>(self, other: NodeId, arena: &Arena<T>) -> bool {
+        other.is_ancestor_of(self, arena)
     }
 
     /// An iterator of the IDs of a given node and its descendants, as a pre-order depth-first search where children are visited in insertion order.

--- a/indextree/src/lib.rs
+++ b/indextree/src/lib.rs
@@ -13,8 +13,9 @@
 //!   environments (requires `alloc`).
 //! * `macros` (default) - Enable the `tree!` macro for declarative tree
 //!   construction.
-//! * `deser` - Enable `serde` serialization and deserialization for
-//!   [`Arena`], [`Node`], and [`NodeId`].
+//! * `serde` - Enable `serde` serialization and deserialization for
+//!   [`Arena`], [`Node`], and [`NodeId`]. (The legacy name `deser` is
+//!   still accepted as an alias.)
 //! * `par_iter` - Enable parallel iteration via `Arena::par_iter()` using
 //!   [rayon](https://docs.rs/rayon).
 //!

--- a/indextree/src/node.rs
+++ b/indextree/src/node.rs
@@ -5,18 +5,18 @@
 //! [`NodeId`](crate::NodeId) to index into an [`Arena`](crate::Arena).
 
 #[cfg(not(feature = "std"))]
-use core::fmt;
+use core::{fmt, hash};
 
-#[cfg(feature = "deser")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
-use std::fmt;
+use std::{fmt, hash};
 
 use crate::{NodeId, id::NodeStamp};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
-#[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub(crate) enum NodeData<T> {
     /// The actual data store
     Data(T),
@@ -25,7 +25,7 @@ pub(crate) enum NodeData<T> {
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
-#[cfg_attr(feature = "deser", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 /// A node within a particular `Arena`.
 pub struct Node<T> {
     // Keep these private (with read-only accessors) so that we can keep them
@@ -54,6 +54,16 @@ impl<T> Node<T> {
         }
     }
 
+    /// Returns a reference to the node data, or `None` if the node has
+    /// been removed.
+    pub fn try_get(&self) -> Option<&T> {
+        if let NodeData::Data(ref data) = self.data {
+            Some(data)
+        } else {
+            None
+        }
+    }
+
     /// Returns a mutable reference to the node data.
     ///
     /// # Panics
@@ -64,6 +74,16 @@ impl<T> Node<T> {
             data
         } else {
             panic!("attempted to access a freed node")
+        }
+    }
+
+    /// Returns a mutable reference to the node data, or `None` if the
+    /// node has been removed.
+    pub fn try_get_mut(&mut self) -> Option<&mut T> {
+        if let NodeData::Data(ref mut data) = self.data {
+            Some(data)
+        } else {
+            None
         }
     }
 
@@ -327,6 +347,27 @@ impl<T> Node<T> {
     /// Checks if the node is detached.
     pub(crate) fn is_detached(&self) -> bool {
         self.parent.is_none() && self.previous_sibling.is_none() && self.next_sibling.is_none()
+    }
+}
+
+impl<T: hash::Hash> hash::Hash for Node<T> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.parent.hash(state);
+        self.previous_sibling.hash(state);
+        self.next_sibling.hash(state);
+        self.first_child.hash(state);
+        self.last_child.hash(state);
+        self.stamp.hash(state);
+        match self.data {
+            NodeData::Data(ref data) => {
+                0u8.hash(state);
+                data.hash(state);
+            }
+            NodeData::NextFree(ref next) => {
+                1u8.hash(state);
+                next.hash(state);
+            }
+        }
     }
 }
 

--- a/indextree/src/traverse.rs
+++ b/indextree/src/traverse.rs
@@ -174,9 +174,7 @@ new_iterator!(
     /// An iterator of the IDs of the siblings before a given node.
     PrecedingSiblings,
     new = |arena, node| {
-        let first = arena
-            .get(node)
-            .unwrap()
+        let first = arena[node]
             .parent
             .and_then(|parent_id| arena.get(parent_id))
             .and_then(|parent| parent.first_child);
@@ -191,9 +189,7 @@ new_iterator!(
     /// An iterator of the IDs of the siblings after a given node.
     FollowingSiblings,
     new = |arena, node| {
-        let last = arena
-            .get(node)
-            .unwrap()
+        let last = arena[node]
             .parent
             .and_then(|parent_id| arena.get(parent_id))
             .and_then(|parent| parent.last_child);

--- a/indextree/tests/lib.rs
+++ b/indextree/tests/lib.rs
@@ -270,7 +270,6 @@ fn reserve() {
 }
 
 #[test]
-#[should_panic(expected = "index out of bounds")]
 fn inaccessible_node() {
     let mut arena = Arena::new();
     let n1_id = arena.new_node("1");
@@ -279,7 +278,7 @@ fn inaccessible_node() {
     assert!(arena.get(n1_id).is_none());
     let n1_id = arena.new_node("1");
     assert_eq!(*arena[n1_id].get(), "1");
-    n2_id.is_removed(&arena);
+    assert!(n2_id.is_removed(&arena));
 }
 
 #[test]
@@ -716,4 +715,202 @@ fn node_display_with_siblings() {
     let display = format!("{}", arena[c3]);
     assert!(display.contains("previous sibling:"));
     assert!(display.contains("no next sibling"));
+}
+
+#[test]
+fn double_remove_is_safe() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = root.append_value("child", &mut arena);
+    child.remove(&mut arena);
+    assert!(child.is_removed(&arena));
+    // Calling remove_subtree on an already-removed node should not corrupt
+    // the free list (free_node guards against double-free).
+    child.remove_subtree(&mut arena);
+    assert!(child.is_removed(&arena));
+    // Arena is still usable
+    let new_node = arena.new_node("new");
+    assert!(!new_node.is_removed(&arena));
+}
+
+#[test]
+fn stale_node_id_after_slot_reuse() {
+    let mut arena = Arena::new();
+    let original = arena.new_node("original");
+    let original_id = original;
+    original.remove(&mut arena);
+
+    let reused = arena.new_node("reused");
+
+    // Stale ID should not see the new data
+    assert!(arena.get(original_id).is_none());
+    assert!(original_id.is_removed(&arena));
+
+    // New ID sees the new data
+    assert_eq!(*arena.get(reused).unwrap().get(), "reused");
+    assert!(!reused.is_removed(&arena));
+
+    // The two IDs are different even though they may share an index
+    assert_ne!(original_id, reused);
+}
+
+#[test]
+fn remove_subtree_leaf_node() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = root.append_value("child", &mut arena);
+    let leaf = child.append_value("leaf", &mut arena);
+
+    leaf.remove_subtree(&mut arena);
+
+    assert!(leaf.is_removed(&arena));
+    assert!(!child.is_removed(&arena));
+    assert!(!root.is_removed(&arena));
+    assert_eq!(child.children(&arena).count(), 0);
+}
+
+#[test]
+fn node_try_get() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("hello");
+    assert_eq!(arena[n1].try_get(), Some(&"hello"));
+
+    n1.remove(&mut arena);
+    assert_eq!(arena[n1].try_get(), None);
+}
+
+#[test]
+fn node_try_get_mut() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node(42);
+    *arena[n1].try_get_mut().unwrap() = 99;
+    assert_eq!(*arena[n1].get(), 99);
+}
+
+#[test]
+fn arena_len() {
+    let mut arena = Arena::new();
+    assert_eq!(arena.len(), 0);
+    let n1 = arena.new_node("a");
+    assert_eq!(arena.len(), 1);
+    arena.new_node("b");
+    assert_eq!(arena.len(), 2);
+    n1.remove(&mut arena);
+    assert_eq!(arena.len(), 2); // removed nodes still counted
+}
+
+#[test]
+fn into_iterator_ref() {
+    let mut arena = Arena::new();
+    arena.new_node(1);
+    arena.new_node(2);
+    arena.new_node(3);
+
+    let values: Vec<_> = (&arena).into_iter().map(|n| *n.get()).collect();
+    assert_eq!(values, vec![1, 2, 3]);
+}
+
+#[test]
+fn into_iterator_mut() {
+    let mut arena: Arena<i32> = Arena::new();
+    arena.new_node(1);
+    arena.new_node(2);
+    arena.new_node(3);
+
+    for node in &mut arena {
+        *node.get_mut() += 10;
+    }
+
+    let values: Vec<_> = (&arena).into_iter().map(|n| *n.get()).collect();
+    assert_eq!(values, vec![11, 12, 13]);
+}
+
+#[test]
+fn depth() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = root.append_value("child", &mut arena);
+    let grandchild = child.append_value("grandchild", &mut arena);
+
+    assert_eq!(root.depth(&arena), 0);
+    assert_eq!(child.depth(&arena), 1);
+    assert_eq!(grandchild.depth(&arena), 2);
+}
+
+#[test]
+fn nth_child() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let c0 = root.append_value("c0", &mut arena);
+    let c1 = root.append_value("c1", &mut arena);
+    let c2 = root.append_value("c2", &mut arena);
+
+    assert_eq!(root.nth_child(0, &arena), Some(c0));
+    assert_eq!(root.nth_child(1, &arena), Some(c1));
+    assert_eq!(root.nth_child(2, &arena), Some(c2));
+    assert_eq!(root.nth_child(3, &arena), None);
+    assert_eq!(c0.nth_child(0, &arena), None);
+}
+
+#[test]
+fn is_ancestor_of() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = root.append_value("child", &mut arena);
+    let grandchild = child.append_value("grandchild", &mut arena);
+
+    assert!(root.is_ancestor_of(child, &arena));
+    assert!(root.is_ancestor_of(grandchild, &arena));
+    assert!(child.is_ancestor_of(grandchild, &arena));
+
+    assert!(!child.is_ancestor_of(root, &arena));
+    assert!(!grandchild.is_ancestor_of(root, &arena));
+    assert!(!root.is_ancestor_of(root, &arena));
+}
+
+#[test]
+fn is_descendant_of() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = root.append_value("child", &mut arena);
+    let grandchild = child.append_value("grandchild", &mut arena);
+
+    assert!(grandchild.is_descendant_of(root, &arena));
+    assert!(child.is_descendant_of(root, &arena));
+    assert!(grandchild.is_descendant_of(child, &arena));
+
+    assert!(!root.is_descendant_of(child, &arena));
+    assert!(!root.is_descendant_of(root, &arena));
+}
+
+#[test]
+fn node_error_eq() {
+    assert_eq!(NodeError::AppendSelf, NodeError::AppendSelf);
+    assert_ne!(NodeError::AppendSelf, NodeError::Removed);
+
+    // Can use assert_eq! with checked_ methods
+    let mut arena = Arena::new();
+    let n = arena.new_node("x");
+    assert_eq!(n.checked_append(n, &mut arena), Err(NodeError::AppendSelf));
+}
+
+#[test]
+fn is_removed_after_clear() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("1");
+    let n2 = arena.new_node("2");
+    arena.clear();
+    // Should not panic, just return true
+    assert!(n1.is_removed(&arena));
+    assert!(n2.is_removed(&arena));
+}
+
+#[test]
+fn get_returns_none_for_removed() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("hello");
+    assert!(arena.get(n1).is_some());
+    n1.remove(&mut arena);
+    assert!(arena.get(n1).is_none());
+    assert!(arena.get_mut(n1).is_none());
 }

--- a/indextree/tests/serde.rs
+++ b/indextree/tests/serde.rs
@@ -1,0 +1,49 @@
+#![cfg(feature = "serde")]
+
+use indextree::Arena;
+
+#[test]
+fn round_trip_empty_arena() {
+    let arena: Arena<i32> = Arena::new();
+    let json = serde_json::to_string(&arena).unwrap();
+    let deserialized: Arena<i32> = serde_json::from_str(&json).unwrap();
+    assert_eq!(arena, deserialized);
+}
+
+#[test]
+fn round_trip_single_node() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("hello");
+    let _ = root; // suppress unused warning
+
+    let json = serde_json::to_string(&arena).unwrap();
+    let deserialized: Arena<&str> = serde_json::from_str(&json).unwrap();
+    assert_eq!(arena, deserialized);
+}
+
+#[test]
+fn round_trip_tree() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(1);
+    let c1 = root.append_value(2, &mut arena);
+    let c2 = root.append_value(3, &mut arena);
+    c1.append_value(4, &mut arena);
+    c2.append_value(5, &mut arena);
+
+    let json = serde_json::to_string(&arena).unwrap();
+    let deserialized: Arena<i32> = serde_json::from_str(&json).unwrap();
+    assert_eq!(arena, deserialized);
+}
+
+#[test]
+fn round_trip_with_removed_node() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(1);
+    let c1 = root.append_value(2, &mut arena);
+    root.append_value(3, &mut arena);
+    c1.remove(&mut arena);
+
+    let json = serde_json::to_string(&arena).unwrap();
+    let deserialized: Arena<i32> = serde_json::from_str(&json).unwrap();
+    assert_eq!(arena, deserialized);
+}


### PR DESCRIPTION
- Validate stamps in `Arena::get`/`get_mut` to prevent stale `NodeId` access
- Guard against double-free in `Arena::free_node`
- Fix `NodeId::is_removed` to not panic after `Arena::clear`
- Add `depth`, `nth_child`, `is_ancestor_of`, `is_descendant_of` to `NodeId`
- Add `try_get`, `try_get_mut` non-panicking accessors to `Node`
- Add `Arena::len`, `IntoIterator` impls, and `par_iter_mut`
- Implement `Hash` for `Node<T>` consistent with `PartialEq`
- Derive `PartialEq + Eq` on `NodeError`
- Rename `deser` feature to `serde` with backward-compatible alias
- Fix proc macro peek-before-parse for `=>` token
- Add CI jobs for cross-platform, nightly, and feature combinations
- Add `clippy --no-default-features` to Makefile
- Add 18 new tests and 4 serde round-trip tests