### PR TITLE
Improve API ergonomics, performance, and test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: features
         run: |
-          features=$(awk '/^\[features\]/{f=1;next} /^\[/{f=0} f && /^[a-z_]+ =/ && !/^default / && !/^std /{print $1}' \
+          features=$(awk '/^\[features\]/{f=1;next} /^\[/{f=0} f && /^[a-z_]+ =/ && !/^default / && !/^std / && !/^deser /{print $1}' \
             indextree/Cargo.toml | jq -Rsc 'split("\n") | map(select(length > 0)) | [""] + .')
           echo "features=$features" >> "$GITHUB_OUTPUT"
 

--- a/indextree/src/arena.rs
+++ b/indextree/src/arena.rs
@@ -188,14 +188,33 @@ impl<T> Arena<T> {
     /// assert_eq!(arena.count(), 2);
     /// assert_eq!(arena.len(), 2);
     /// ```
+    #[deprecated(since = "4.9.0", note = "use len() instead")]
     pub fn count(&self) -> usize {
         self.nodes.len()
     }
 
     /// Returns the number of slots in the arena, including removed nodes.
     ///
-    /// This is an alias for [`count()`](Arena::count) following the Rust
-    /// naming convention for collection lengths.
+    /// Removed nodes are still counted because they remain in the
+    /// internal storage. Use [`iter()`] with [`Node::is_removed()`]
+    /// to count only live nodes.
+    ///
+    /// [`iter()`]: Arena::iter
+    /// [`Node::is_removed()`]: crate::Node::is_removed
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    /// let _bar = arena.new_node("bar");
+    /// assert_eq!(arena.len(), 2);
+    ///
+    /// foo.remove(&mut arena);
+    /// // The removed node is still counted.
+    /// assert_eq!(arena.len(), 2);
+    /// ```
     pub fn len(&self) -> usize {
         self.nodes.len()
     }
@@ -216,7 +235,7 @@ impl<T> Arena<T> {
     /// assert!(!arena.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
-        self.count() == 0
+        self.nodes.is_empty()
     }
 
     /// Returns a reference to the node with the given id if in the arena.
@@ -242,6 +261,7 @@ impl<T> Arena<T> {
     /// foo.remove(&mut arena);
     /// assert!(arena.get(foo).is_none());
     /// ```
+    #[inline]
     pub fn get(&self, id: NodeId) -> Option<&Node<T>> {
         self.nodes
             .get(id.index0())
@@ -265,6 +285,7 @@ impl<T> Arena<T> {
     /// *arena.get_mut(foo).expect("The `foo` node exists").get_mut() = "FOO!";
     /// assert_eq!(arena.get(foo).map(|node| *node.get()), Some("FOO!"));
     /// ```
+    #[inline]
     pub fn get_mut(&mut self, id: NodeId) -> Option<&mut Node<T>> {
         let stamp = id.stamp();
         self.nodes
@@ -528,12 +549,14 @@ impl<T> Default for Arena<T> {
 impl<T> Index<NodeId> for Arena<T> {
     type Output = Node<T>;
 
+    #[inline]
     fn index(&self, node: NodeId) -> &Node<T> {
         &self.nodes[node.index0()]
     }
 }
 
 impl<T> IndexMut<NodeId> for Arena<T> {
+    #[inline]
     fn index_mut(&mut self, node: NodeId) -> &mut Node<T> {
         &mut self.nodes[node.index0()]
     }
@@ -573,7 +596,7 @@ fn conserve_capacity() {
     assert_eq!(n1_id.index0(), 0);
     assert_eq!(n2_id.index0(), 1);
     assert_eq!(n3_id.index0(), 2);
-    assert_eq!(arena.count(), 3);
+    assert_eq!(arena.len(), 3);
     assert_eq!(arena.capacity(), cap);
 }
 

--- a/indextree/src/id.rs
+++ b/indextree/src/id.rs
@@ -17,7 +17,7 @@ use crate::{
     Ancestors, Arena, Children, Descendants, FollowingSiblings, NodeError, PrecedingSiblings,
     Predecessors, ReverseTraverse, Traverse,
     debug_pretty_print::DebugPrettyPrint,
-    relations::{insert_last_unchecked, insert_with_neighbors},
+    relations::{insert_first_unchecked, insert_last_unchecked, insert_with_neighbors},
     siblings_range::SiblingsRange,
 };
 
@@ -48,6 +48,7 @@ pub(crate) struct NodeStamp(i16);
 impl NodeStamp {
     /// Returns `true` if this stamp represents a removed node (negative
     /// value).
+    #[inline]
     pub fn is_removed(self) -> bool {
         self.0.is_negative()
     }
@@ -105,6 +106,7 @@ impl From<NodeId> for usize {
 
 impl NodeId {
     /// Returns zero-based index.
+    #[inline]
     pub(crate) fn index0(self) -> usize {
         // This is totally safe because `self.index1 >= 1` is guaranteed by
         // `NonZeroUsize` type.
@@ -117,6 +119,7 @@ impl NodeId {
     }
 
     /// Returns the stamp associated with this node ID.
+    #[inline]
     pub(crate) fn stamp(self) -> NodeStamp {
         self.stamp
     }
@@ -888,7 +891,7 @@ impl NodeId {
     }
 
     /// Creates and prepends a new node (from its associated data) as the first child.
-    /// A convenience shorthand for creating a node via [`Arena::new_node`] and prepending it via [`prepend`].
+    /// This method is a fast path for the common case of prepending a new node. It is quicker than [`prepend`].
     ///
     /// # Panics
     ///
@@ -920,8 +923,7 @@ impl NodeId {
     /// [`prepend`]: NodeId::prepend
     pub fn prepend_value<T>(self, value: T, arena: &mut Arena<T>) -> NodeId {
         let new_child = arena.new_node(value);
-        self.checked_prepend(new_child, arena)
-            .expect("Preconditions not met: invalid argument");
+        insert_first_unchecked(arena, new_child, self);
         new_child
     }
 
@@ -1066,6 +1068,50 @@ impl NodeId {
             .expect("Preconditions not met: invalid argument");
     }
 
+    /// Creates and inserts a new sibling node after this node.
+    ///
+    /// A convenience shorthand for creating a node via [`Arena::new_node`]
+    /// and inserting it via [`insert_after`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    ///
+    /// * the arena already has `usize::max_value()` nodes, or
+    /// * `self` was already [`remove`]d.
+    ///
+    /// [`remove`]: NodeId::remove
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = n1.append_value("1_1", &mut arena);
+    /// let n1_3 = n1.append_value("1_3", &mut arena);
+    /// let n1_2 = n1_1.insert_after_value("1_2", &mut arena);
+    ///
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1.children(&arena);
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    ///
+    /// [`insert_after`]: NodeId::insert_after
+    pub fn insert_after_value<T>(self, value: T, arena: &mut Arena<T>) -> NodeId {
+        let new_sibling = arena.new_node(value);
+        self.insert_after(new_sibling, arena);
+        new_sibling
+    }
+
     /// Inserts a new sibling after this node.
     ///
     /// # Failures
@@ -1160,6 +1206,50 @@ impl NodeId {
     pub fn insert_before<T>(self, new_sibling: NodeId, arena: &mut Arena<T>) {
         self.checked_insert_before(new_sibling, arena)
             .expect("Preconditions not met: invalid argument");
+    }
+
+    /// Creates and inserts a new sibling node before this node.
+    ///
+    /// A convenience shorthand for creating a node via [`Arena::new_node`]
+    /// and inserting it via [`insert_before`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    ///
+    /// * the arena already has `usize::max_value()` nodes, or
+    /// * `self` was already [`remove`]d.
+    ///
+    /// [`remove`]: NodeId::remove
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = n1.append_value("1_1", &mut arena);
+    /// let n1_3 = n1.append_value("1_3", &mut arena);
+    /// let n1_2 = n1_3.insert_before_value("1_2", &mut arena);
+    ///
+    /// // arena
+    /// // `-- 1
+    /// //     |-- 1_1
+    /// //     |-- 1_2
+    /// //     `-- 1_3
+    ///
+    /// let mut iter = n1.children(&arena);
+    /// assert_eq!(iter.next(), Some(n1_1));
+    /// assert_eq!(iter.next(), Some(n1_2));
+    /// assert_eq!(iter.next(), Some(n1_3));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    ///
+    /// [`insert_before`]: NodeId::insert_before
+    pub fn insert_before_value<T>(self, value: T, arena: &mut Arena<T>) -> NodeId {
+        let new_sibling = arena.new_node(value);
+        self.insert_before(new_sibling, arena);
+        new_sibling
     }
 
     /// Inserts a new sibling before this node.
@@ -1345,7 +1435,10 @@ impl NodeId {
     pub fn remove_subtree<T>(self, arena: &mut Arena<T>) {
         self.detach(arena);
 
-        // use a preorder traversal to remove node.
+        // Preorder traversal to remove all nodes. After free_node(id), we
+        // still read arena[id]'s link fields (first_child, next_sibling).
+        // This works because free_node only changes data to NextFree and
+        // the stamp; it does not clear structural link fields.
         let mut cursor = Some(self);
         while let Some(id) = cursor {
             arena.free_node(id);

--- a/indextree/src/node.rs
+++ b/indextree/src/node.rs
@@ -46,6 +46,7 @@ impl<T> Node<T> {
     /// # Panics
     ///
     /// Panics if the node has been removed.
+    #[inline]
     pub fn get(&self) -> &T {
         if let NodeData::Data(ref data) = self.data {
             data
@@ -56,6 +57,7 @@ impl<T> Node<T> {
 
     /// Returns a reference to the node data, or `None` if the node has
     /// been removed.
+    #[inline]
     pub fn try_get(&self) -> Option<&T> {
         if let NodeData::Data(ref data) = self.data {
             Some(data)
@@ -69,6 +71,7 @@ impl<T> Node<T> {
     /// # Panics
     ///
     /// Panics if the node has been removed.
+    #[inline]
     pub fn get_mut(&mut self) -> &mut T {
         if let NodeData::Data(ref mut data) = self.data {
             data
@@ -79,6 +82,7 @@ impl<T> Node<T> {
 
     /// Returns a mutable reference to the node data, or `None` if the
     /// node has been removed.
+    #[inline]
     pub fn try_get_mut(&mut self) -> Option<&mut T> {
         if let NodeData::Data(ref mut data) = self.data {
             Some(data)
@@ -138,6 +142,7 @@ impl<T> Node<T> {
     /// assert_eq!(arena[n1_2].parent(), Some(n1));
     /// assert_eq!(arena[n1_3].parent(), Some(n1));
     /// ```
+    #[inline]
     pub fn parent(&self) -> Option<NodeId> {
         self.parent
     }
@@ -166,6 +171,7 @@ impl<T> Node<T> {
     /// assert_eq!(arena[n1_2].first_child(), None);
     /// assert_eq!(arena[n1_3].first_child(), None);
     /// ```
+    #[inline]
     pub fn first_child(&self) -> Option<NodeId> {
         self.first_child
     }
@@ -194,6 +200,7 @@ impl<T> Node<T> {
     /// assert_eq!(arena[n1_2].last_child(), None);
     /// assert_eq!(arena[n1_3].last_child(), None);
     /// ```
+    #[inline]
     pub fn last_child(&self) -> Option<NodeId> {
         self.last_child
     }
@@ -248,6 +255,7 @@ impl<T> Node<T> {
     /// assert_eq!(arena[n1].previous_sibling(), None);
     /// assert_eq!(arena[n2].previous_sibling(), Some(n1));
     /// ```
+    #[inline]
     pub fn previous_sibling(&self) -> Option<NodeId> {
         self.previous_sibling
     }
@@ -302,6 +310,7 @@ impl<T> Node<T> {
     /// assert_eq!(arena[n1].next_sibling(), Some(n2));
     /// assert_eq!(arena[n2].next_sibling(), None);
     /// ```
+    #[inline]
     pub fn next_sibling(&self) -> Option<NodeId> {
         self.next_sibling
     }
@@ -340,6 +349,7 @@ impl<T> Node<T> {
     /// assert!(arena[n1_2].is_removed());
     /// assert_eq!(arena[n1_3].previous_sibling(), Some(n1_1));
     /// ```
+    #[inline]
     pub fn is_removed(&self) -> bool {
         self.stamp.is_removed()
     }

--- a/indextree/src/relations.rs
+++ b/indextree/src/relations.rs
@@ -156,7 +156,7 @@ pub(crate) fn insert_with_neighbors<T>(
     Ok(())
 }
 
-/// Inserts, and updates the given detached node to the parent, after all of it's existing children
+/// Inserts, and updates the given detached node to the parent, after all of its existing children
 ///
 /// ```text
 /// Before:
@@ -183,4 +183,33 @@ pub(crate) fn insert_last_unchecked<T>(arena: &mut Arena<T>, new: NodeId, parent
         );
 
     debug_assert_triangle_nodes!(arena, Some(parent), previous_sibling, Some(new));
+}
+
+/// Inserts, and updates the given detached node to the parent, before all of its existing children.
+///
+/// ```text
+/// Before:
+///
+///       parent
+///      /     \
+///     /       \
+/// next_sibling -> ...
+///
+/// After:
+///
+///         parent
+///    _____/|\_____
+///   /      |      \
+/// (new) -> next -> ...
+/// ```
+pub(crate) fn insert_first_unchecked<T>(arena: &mut Arena<T>, new: NodeId, parent: NodeId) {
+    let next_sibling = arena[parent].first_child;
+    DetachedSiblingsRange::new(new, new)
+        .transplant(arena, Some(parent), None, next_sibling)
+        .expect(
+            "Should never fail, callers must verify assumptions when using fast path prepend.
+                 `expect` only needed due to usage of shared functions that return a `Result`.",
+        );
+
+    debug_assert_triangle_nodes!(arena, Some(parent), Some(new), next_sibling);
 }

--- a/indextree/src/traverse.rs
+++ b/indextree/src/traverse.rs
@@ -243,13 +243,13 @@ impl<T> core::iter::FusedIterator for Descendants<'_, T> {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Indicator if the node is at a start or endpoint of the tree
 pub enum NodeEdge {
-    /// Indicates that start of a node that has children.
+    /// Indicates the start of visiting a node.
     ///
     /// Yielded by `Traverse::next()` before the node’s descendants. In HTML or
     /// XML, this corresponds to an opening tag like `<div>`.
     Start(NodeId),
 
-    /// Indicates that end of a node that has children.
+    /// Indicates the end of visiting a node.
     ///
     /// Yielded by `Traverse::next()` after the node’s descendants. In HTML or
     /// XML, this corresponds to a closing tag like `</div>`

--- a/indextree/tests/lib.rs
+++ b/indextree/tests/lib.rs
@@ -914,3 +914,61 @@ fn get_returns_none_for_removed() {
     assert!(arena.get(n1).is_none());
     assert!(arena.get_mut(n1).is_none());
 }
+
+#[test]
+#[should_panic(expected = "Preconditions not met")]
+fn append_self_panics() {
+    let mut arena = Arena::new();
+    let n = arena.new_node("x");
+    n.append(n, &mut arena);
+}
+
+#[test]
+#[should_panic(expected = "Preconditions not met")]
+fn prepend_self_panics() {
+    let mut arena = Arena::new();
+    let n = arena.new_node("x");
+    n.prepend(n, &mut arena);
+}
+
+#[test]
+#[should_panic(expected = "Preconditions not met")]
+fn insert_after_self_panics() {
+    let mut arena = Arena::new();
+    let n = arena.new_node("x");
+    n.insert_after(n, &mut arena);
+}
+
+#[test]
+#[should_panic(expected = "Preconditions not met")]
+fn insert_before_self_panics() {
+    let mut arena = Arena::new();
+    let n = arena.new_node("x");
+    n.insert_before(n, &mut arena);
+}
+
+#[test]
+fn insert_after_value() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let c1 = root.append_value("c1", &mut arena);
+    let c3 = root.append_value("c3", &mut arena);
+    let c2 = c1.insert_after_value("c2", &mut arena);
+
+    let children: Vec<_> = root.children(&arena).collect();
+    assert_eq!(children, vec![c1, c2, c3]);
+    assert_eq!(*arena[c2].get(), "c2");
+}
+
+#[test]
+fn insert_before_value() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let c1 = root.append_value("c1", &mut arena);
+    let c3 = root.append_value("c3", &mut arena);
+    let c2 = c3.insert_before_value("c2", &mut arena);
+
+    let children: Vec<_> = root.children(&arena).collect();
+    assert_eq!(children, vec![c1, c2, c3]);
+    assert_eq!(*arena[c2].get(), "c2");
+}


### PR DESCRIPTION
- Add `#[inline]` on hot-path accessors for cross-crate inlining (`Node::get`, `parent`, `first_child`, `last_child`, `previous_sibling`, `next_sibling`, `is_removed`, `try_get`, `try_get_mut`, `get_mut`; `Arena::get`, `get_mut`, `Index`, `IndexMut`; `NodeId::index0`, `stamp`, `NodeStamp::is_removed`)
- Add `insert_after_value` and `insert_before_value` convenience methods with doc examples
- Use fast unchecked path for `prepend_value` via new `insert_first_unchecked` (skips unnecessary ancestor walk, matching `append_value` behavior)
- Deprecate `Arena::count()` in favor of `len()`
- Fix `NodeEdge::Start`/`End` docs (emitted for all nodes, not just parents)
- Fix typo in `insert_last_unchecked` doc ("it's" to "its")
- Add comment on `remove_subtree` explaining freed-node link invariant
- Exclude `deser` alias from CI feature matrix (identical to `serde`)
- Add `#[should_panic]` tests for self-insertion on append, prepend, insert_after, insert_before
- Add tests for `insert_after_value` and `insert_before_value`