### PR TITLE
Improve API ergonomics, performance, docs, and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,26 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: stable
+      - run: cargo generate-lockfile
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target
+            ~/.cargo/registry
+          key: rust-semver-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-semver-
+      - uses: taiki-e/install-action@6cd13508893c0e7eab5f273c2575d3859bd7229a # v2.86.6
+        with:
+          tool: cargo-semver-checks
+      - run: cargo semver-checks
+
   doc:
     runs-on: ubuntu-latest
     steps:

--- a/indextree-macros/Cargo.toml
+++ b/indextree-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "indextree-macros"
 version = "0.1.3"
 edition = "2024"
+rust-version = "1.85.0"
 license = "MIT"
 authors = ["Sascha Grunert <mail@saschagrunert.de>"]
 repository = "https://github.com/saschagrunert/indextree"
@@ -19,4 +20,4 @@ quote = "1.0.40"
 syn = { version = "3.0.2", features = ["full"] }
 
 [dev-dependencies]
-indextree = { path = "../indextree", version = "4.8.1" }
+indextree = { path = "../indextree", version = "4.9.0" }

--- a/indextree/Cargo.toml
+++ b/indextree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indextree"
-version = "4.8.1"
+version = "4.9.0"
 license = "MIT"
 readme = "../README.md"
 keywords = ["tree", "arena", "index", "indextree"]
@@ -16,6 +16,7 @@ rust-version = "1.85.0"
 [features]
 default = ["std", "macros"]
 serde = ["dep:serde"]
+# Deprecated alias for `serde`. Use `serde` instead.
 deser = ["serde"]
 par_iter = ["rayon"]
 std = []

--- a/indextree/src/arena.rs
+++ b/indextree/src/arena.rs
@@ -5,7 +5,7 @@
 //! Removed nodes are recycled through an internal free list.
 
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::vec::{self, Vec};
 
 #[cfg(not(feature = "std"))]
 use core::{
@@ -26,7 +26,7 @@ use std::{
     mem,
     num::NonZeroUsize,
     ops::{Index, IndexMut},
-    slice,
+    slice, vec,
 };
 
 use crate::{Node, NodeId, node::NodeData};
@@ -48,6 +48,14 @@ impl<T> Arena<T> {
     }
 
     /// Creates a new empty `Arena` with enough capacity to store `n` nodes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let arena: Arena<i32> = Arena::with_capacity(10);
+    /// assert!(arena.capacity() >= 10);
+    /// ```
     #[must_use]
     pub fn with_capacity(n: usize) -> Self {
         Self {
@@ -58,6 +66,14 @@ impl<T> Arena<T> {
     }
 
     /// Returns the number of nodes the arena can hold without reallocating.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let arena: Arena<i32> = Arena::with_capacity(10);
+    /// assert!(arena.capacity() >= 10);
+    /// ```
     pub fn capacity(&self) -> usize {
         self.nodes.capacity()
     }
@@ -69,6 +85,15 @@ impl<T> Arena<T> {
     /// # Panics
     ///
     /// Panics if the new capacity exceeds isize::MAX bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena: Arena<i32> = Arena::new();
+    /// arena.reserve(100);
+    /// assert!(arena.capacity() >= 100);
+    /// ```
     pub fn reserve(&mut self, additional: usize) {
         self.nodes.reserve(additional);
     }
@@ -298,6 +323,9 @@ impl<T> Arena<T> {
     /// Note that this iterator returns also removed elements, which can be
     /// tested with the [`is_removed()`] method on the node.
     ///
+    /// To iterate over only live nodes by their [`NodeId`], use
+    /// [`iter_node_ids()`](Arena::iter_node_ids) instead.
+    ///
     /// # Examples
     ///
     /// ```
@@ -388,6 +416,35 @@ impl<T> Arena<T> {
         self.nodes.iter_mut()
     }
 
+    /// Shrinks the internal storage to fit the current number of nodes.
+    ///
+    /// Calls [`Vec::shrink_to_fit`] on the underlying node storage.
+    pub fn shrink_to_fit(&mut self) {
+        self.nodes.shrink_to_fit();
+    }
+
+    /// Returns the number of live (non-removed) nodes in the arena.
+    ///
+    /// This is O(n) as it scans all slots. For the total slot count
+    /// (including removed nodes), use [`len()`](Arena::len).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    /// let bar = arena.new_node("bar");
+    /// assert_eq!(arena.live_count(), 2);
+    ///
+    /// foo.remove(&mut arena);
+    /// assert_eq!(arena.live_count(), 1);
+    /// assert_eq!(arena.len(), 2);
+    /// ```
+    pub fn live_count(&self) -> usize {
+        self.nodes.iter().filter(|n| !n.is_removed()).count()
+    }
+
     /// Clears all the nodes in the arena, but retains its allocated capacity.
     ///
     /// Note that this does not mark all nodes as removed, but completely
@@ -397,6 +454,17 @@ impl<T> Arena<T> {
     /// After clearing, [`NodeId::is_removed`] returns `true` for any
     /// previously created ID (without panicking), and [`Arena::get`]
     /// returns `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    /// arena.clear();
+    /// assert!(arena.is_empty());
+    /// assert!(foo.is_removed(&arena));
+    /// ```
     pub fn clear(&mut self) {
         self.nodes.clear();
         self.first_free_slot = None;
@@ -409,6 +477,16 @@ impl<T> Arena<T> {
     /// nodes. Use [`Node::is_removed()`] to filter them out.
     ///
     /// [`Node::is_removed()`]: crate::Node::is_removed
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// arena.new_node("foo");
+    /// arena.new_node("bar");
+    /// assert_eq!(arena.as_slice().len(), 2);
+    /// ```
     pub fn as_slice(&self) -> &[Node<T>] {
         self.nodes.as_slice()
     }
@@ -536,6 +614,16 @@ impl<'a, T> IntoIterator for &'a mut Arena<T> {
     }
 }
 
+/// Consumes the arena, returning an iterator over all nodes (including removed ones).
+impl<T> IntoIterator for Arena<T> {
+    type Item = Node<T>;
+    type IntoIter = vec::IntoIter<Node<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.nodes.into_iter()
+    }
+}
+
 impl<T> Default for Arena<T> {
     fn default() -> Self {
         Self {
@@ -546,6 +634,11 @@ impl<T> Default for Arena<T> {
     }
 }
 
+/// Index by [`NodeId`] for convenient `arena[id]` access.
+///
+/// Unlike [`Arena::get`], this does **not** validate the node's stamp,
+/// so it may silently return data from a reused slot if the `NodeId`
+/// is stale. For safe access, prefer [`Arena::get`] or [`Arena::get_mut`].
 impl<T> Index<NodeId> for Arena<T> {
     type Output = Node<T>;
 

--- a/indextree/src/id.rs
+++ b/indextree/src/id.rs
@@ -49,7 +49,7 @@ impl NodeStamp {
     /// Returns `true` if this stamp represents a removed node (negative
     /// value).
     #[inline]
-    pub fn is_removed(self) -> bool {
+    pub(crate) fn is_removed(self) -> bool {
         self.0.is_negative()
     }
 
@@ -57,7 +57,7 @@ impl NodeStamp {
     ///
     /// The resulting negative value differs from the live stamp, allowing
     /// `NodeId::is_removed` to detect stale references via inequality.
-    pub fn mark_removed(&mut self) {
+    pub(crate) fn mark_removed(&mut self) {
         debug_assert!(!self.is_removed());
         self.0 = if self.0 < i16::MAX {
             -self.0 - 1
@@ -70,7 +70,7 @@ impl NodeStamp {
     ///
     /// A slot becomes permanently unreusable once its generation nears
     /// `i16::MIN`, preventing stamp value collisions after many cycles.
-    pub fn reuseable(self) -> bool {
+    pub(crate) fn reuseable(self) -> bool {
         debug_assert!(self.is_removed());
         self.0 > i16::MIN + 1
     }
@@ -79,7 +79,7 @@ impl NodeStamp {
     ///
     /// Negates the value back to positive, producing a new generation
     /// that differs from all previous stamps for this slot.
-    pub fn reuse(&mut self) -> Self {
+    pub(crate) fn reuse(&mut self) -> Self {
         debug_assert!(self.reuseable());
         self.0 = -self.0;
         *self
@@ -165,6 +165,143 @@ impl NodeId {
     /// ```
     pub fn parent<T>(self, arena: &Arena<T>) -> Option<Self> {
         arena[self].parent()
+    }
+
+    /// Returns the ID of the first child of this node, unless it has no child.
+    ///
+    /// Shorthand for `arena[self].first_child()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = n1.append_value("1_1", &mut arena);
+    ///
+    /// assert_eq!(n1.first_child(&arena), Some(n1_1));
+    /// assert_eq!(n1_1.first_child(&arena), None);
+    /// ```
+    #[inline]
+    pub fn first_child<T>(self, arena: &Arena<T>) -> Option<Self> {
+        arena[self].first_child()
+    }
+
+    /// Returns the ID of the last child of this node, unless it has no child.
+    ///
+    /// Shorthand for `arena[self].last_child()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = n1.append_value("1_1", &mut arena);
+    /// let n1_2 = n1.append_value("1_2", &mut arena);
+    ///
+    /// assert_eq!(n1.last_child(&arena), Some(n1_2));
+    /// assert_eq!(n1_1.last_child(&arena), None);
+    /// ```
+    #[inline]
+    pub fn last_child<T>(self, arena: &Arena<T>) -> Option<Self> {
+        arena[self].last_child()
+    }
+
+    /// Returns the ID of the next sibling of this node.
+    ///
+    /// Shorthand for `arena[self].next_sibling()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = n1.append_value("1_1", &mut arena);
+    /// let n1_2 = n1.append_value("1_2", &mut arena);
+    ///
+    /// assert_eq!(n1_1.next_sibling(&arena), Some(n1_2));
+    /// assert_eq!(n1_2.next_sibling(&arena), None);
+    /// ```
+    #[inline]
+    pub fn next_sibling<T>(self, arena: &Arena<T>) -> Option<Self> {
+        arena[self].next_sibling()
+    }
+
+    /// Returns the ID of the previous sibling of this node.
+    ///
+    /// Shorthand for `arena[self].previous_sibling()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = n1.append_value("1_1", &mut arena);
+    /// let n1_2 = n1.append_value("1_2", &mut arena);
+    ///
+    /// assert_eq!(n1_2.previous_sibling(&arena), Some(n1_1));
+    /// assert_eq!(n1_1.previous_sibling(&arena), None);
+    /// ```
+    #[inline]
+    pub fn previous_sibling<T>(self, arena: &Arena<T>) -> Option<Self> {
+        arena[self].previous_sibling()
+    }
+
+    /// Returns `true` if this node has at least one child.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = n1.append_value("1_1", &mut arena);
+    ///
+    /// assert!(n1.has_children(&arena));
+    /// assert!(!n1_1.has_children(&arena));
+    /// ```
+    #[inline]
+    pub fn has_children<T>(self, arena: &Arena<T>) -> bool {
+        arena[self].first_child().is_some()
+    }
+
+    /// Returns `true` if this node has no children.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = n1.append_value("1_1", &mut arena);
+    ///
+    /// assert!(!n1.is_leaf(&arena));
+    /// assert!(n1_1.is_leaf(&arena));
+    /// ```
+    #[inline]
+    pub fn is_leaf<T>(self, arena: &Arena<T>) -> bool {
+        !self.has_children(arena)
+    }
+
+    /// Returns `true` if this node has no parent.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let n1 = arena.new_node("1");
+    /// let n1_1 = n1.append_value("1_1", &mut arena);
+    ///
+    /// assert!(n1.is_root(&arena));
+    /// assert!(!n1_1.is_root(&arena));
+    /// ```
+    #[inline]
+    pub fn is_root<T>(self, arena: &Arena<T>) -> bool {
+        arena[self].parent().is_none()
     }
 
     /// Returns an iterator of IDs of this node and its ancestors.
@@ -1496,10 +1633,14 @@ impl NodeId {
     /// assert_eq!(arena[n1_2_1].parent(), Some(n1_2));
     /// ```
     pub fn detach_children<T>(self, arena: &mut Arena<T>) {
-        let mut child_opt = arena[self].first_child;
+        let first = arena[self].first_child.take();
+        arena[self].last_child = None;
+
+        let mut child_opt = first;
         while let Some(child) = child_opt {
-            let next = arena[child].next_sibling;
-            child.detach(arena);
+            let next = arena[child].next_sibling.take();
+            arena[child].previous_sibling = None;
+            arena[child].parent = None;
             child_opt = next;
         }
     }

--- a/indextree/src/lib.rs
+++ b/indextree/src/lib.rs
@@ -64,6 +64,7 @@
 //! ));
 //! ```
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]

--- a/indextree/src/node.rs
+++ b/indextree/src/node.rs
@@ -46,6 +46,15 @@ impl<T> Node<T> {
     /// # Panics
     ///
     /// Panics if the node has been removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let id = arena.new_node(42);
+    /// assert_eq!(*arena[id].get(), 42);
+    /// ```
     #[inline]
     pub fn get(&self) -> &T {
         if let NodeData::Data(ref data) = self.data {
@@ -57,6 +66,15 @@ impl<T> Node<T> {
 
     /// Returns a reference to the node data, or `None` if the node has
     /// been removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let id = arena.new_node(42);
+    /// assert_eq!(arena[id].try_get(), Some(&42));
+    /// ```
     #[inline]
     pub fn try_get(&self) -> Option<&T> {
         if let NodeData::Data(ref data) = self.data {
@@ -71,6 +89,16 @@ impl<T> Node<T> {
     /// # Panics
     ///
     /// Panics if the node has been removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let id = arena.new_node(42);
+    /// *arena[id].get_mut() = 99;
+    /// assert_eq!(*arena[id].get(), 99);
+    /// ```
     #[inline]
     pub fn get_mut(&mut self) -> &mut T {
         if let NodeData::Data(ref mut data) = self.data {
@@ -82,6 +110,18 @@ impl<T> Node<T> {
 
     /// Returns a mutable reference to the node data, or `None` if the
     /// node has been removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let id = arena.new_node(42);
+    /// if let Some(data) = arena[id].try_get_mut() {
+    ///     *data = 99;
+    /// }
+    /// assert_eq!(*arena[id].get(), 99);
+    /// ```
     #[inline]
     pub fn try_get_mut(&mut self) -> Option<&mut T> {
         if let NodeData::Data(ref mut data) = self.data {

--- a/indextree/src/traverse.rs
+++ b/indextree/src/traverse.rs
@@ -5,8 +5,6 @@
 //! All iterators are lazy, implement [`FusedIterator`](core::iter::FusedIterator),
 //! and provide [`size_hint`](Iterator::size_hint) bounds.
 
-#![allow(clippy::redundant_closure_call)]
-
 use crate::{Arena, Node, NodeId};
 
 #[derive(Clone)]
@@ -51,6 +49,7 @@ macro_rules! new_iterator {
         pub struct $name<'a, T>($inner<'a, T>);
 
         impl<'a, T> $name<'a, T> {
+            #[allow(clippy::redundant_closure_call)]
             pub(crate) fn new(arena: &'a Arena<T>, node: NodeId) -> Self {
                 let new: fn(&'a Arena<T>, NodeId) -> $inner<'a, T> = $new;
                 Self(new(arena, node))
@@ -65,6 +64,7 @@ macro_rules! new_iterator {
             new = $new,
         );
 
+        #[allow(clippy::redundant_closure_call)]
         impl<'a, T> Iterator for $name<'a, T> {
             type Item = NodeId;
 
@@ -91,6 +91,7 @@ macro_rules! new_iterator {
             new = $new,
         );
 
+        #[allow(clippy::redundant_closure_call)]
         impl<'a, T> Iterator for $name<'a, T> {
             type Item = NodeId;
 
@@ -117,6 +118,7 @@ macro_rules! new_iterator {
             }
         }
 
+        #[allow(clippy::redundant_closure_call)]
         impl<'a, T> ::core::iter::DoubleEndedIterator for $name<'a, T> {
             fn next_back(&mut self) -> Option<Self::Item> {
                 match (self.0.head, self.0.tail) {
@@ -209,14 +211,23 @@ new_iterator!(
 );
 
 #[derive(Clone)]
-/// An iterator of the IDs of a given node and its descendants, as a pre-order depth-first search where children are visited in insertion order.
+/// An iterator of the IDs of a given node and its descendants, as a
+/// pre-order depth-first search where children are visited in insertion order.
 ///
 /// i.e. node -> first child -> second child
-pub struct Descendants<'a, T>(Traverse<'a, T>);
+pub struct Descendants<'a, T> {
+    arena: &'a Arena<T>,
+    root: NodeId,
+    next: Option<NodeId>,
+}
 
 impl<'a, T> Descendants<'a, T> {
     pub(crate) fn new(arena: &'a Arena<T>, current: NodeId) -> Self {
-        Self(Traverse::new(arena, current))
+        Self {
+            arena,
+            root: current,
+            next: Some(current),
+        }
     }
 }
 
@@ -224,17 +235,37 @@ impl<T> Iterator for Descendants<'_, T> {
     type Item = NodeId;
 
     fn next(&mut self) -> Option<NodeId> {
-        self.0.find_map(|edge| match edge {
-            NodeEdge::Start(node) => Some(node),
-            NodeEdge::End(_) => None,
-        })
+        let current = self.next.take()?;
+        let node = &self.arena[current];
+
+        self.next = node.first_child.or_else(|| {
+            if current == self.root {
+                return None;
+            }
+            node.next_sibling.or_else(|| {
+                let mut ancestor = node.parent;
+                while let Some(a) = ancestor {
+                    if a == self.root {
+                        return None;
+                    }
+                    if let Some(sib) = self.arena[a].next_sibling {
+                        return Some(sib);
+                    }
+                    ancestor = self.arena[a].parent;
+                }
+                None
+            })
+        });
+
+        Some(current)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (low, _) = self.0.size_hint();
-        // Each descendant produces a Start and End edge, so at least low/2
-        // descendants remain, but at minimum 1 if any edges remain.
-        if low > 0 { (1, None) } else { (0, Some(0)) }
+        if self.next.is_some() {
+            (1, None)
+        } else {
+            (0, Some(0))
+        }
     }
 }
 

--- a/indextree/tests/lib.rs
+++ b/indextree/tests/lib.rs
@@ -972,3 +972,180 @@ fn insert_before_value() {
     assert_eq!(children, vec![c1, c2, c3]);
     assert_eq!(*arena[c2].get(), "c2");
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn serde_round_trip_with_free_list() {
+    let mut arena = Arena::new();
+    let n1 = arena.new_node("a");
+    let n2 = arena.new_node("b");
+    let n3 = arena.new_node("c");
+    n1.append(n3, &mut arena);
+
+    // Remove n2 to populate the free list
+    n2.remove(&mut arena);
+
+    let json = serde_json::to_string(&arena).unwrap();
+    let deserialized: Arena<&str> = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(arena, deserialized);
+
+    // Verify the free list works after deserialization by allocating a new node
+    let mut deserialized = deserialized;
+    let n4 = deserialized.new_node("d");
+    // The new node should reuse n2's slot (same 1-based index)
+    assert_eq!(usize::from(n4), usize::from(n2));
+    assert_eq!(*deserialized[n4].get(), "d");
+}
+
+#[cfg(feature = "par_iter")]
+#[test]
+fn par_iter_mut() {
+    let mut arena: Arena<i64> = Arena::new();
+    let root = arena.new_node(1);
+    root.append_value(2, &mut arena);
+    root.append_value(3, &mut arena);
+
+    arena.par_iter_mut().for_each(|node| {
+        if let Some(data) = node.try_get_mut() {
+            *data *= 10;
+        }
+    });
+
+    let sum: i64 = arena.par_iter().map(|node| *node.get()).sum();
+    assert_eq!(sum, 60);
+}
+
+#[test]
+fn remove_subtree_on_root() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let c1 = root.append_value("c1", &mut arena);
+    let c2 = root.append_value("c2", &mut arena);
+    let gc1 = c1.append_value("gc1", &mut arena);
+
+    root.remove_subtree(&mut arena);
+
+    assert!(root.is_removed(&arena));
+    assert!(c1.is_removed(&arena));
+    assert!(c2.is_removed(&arena));
+    assert!(gc1.is_removed(&arena));
+}
+
+#[test]
+fn children_double_ended_interleaved() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let c1 = root.append_value("c1", &mut arena);
+    let c2 = root.append_value("c2", &mut arena);
+    let c3 = root.append_value("c3", &mut arena);
+    let c4 = root.append_value("c4", &mut arena);
+
+    let mut iter = root.children(&arena);
+    assert_eq!(iter.next(), Some(c1));
+    assert_eq!(iter.next_back(), Some(c4));
+    assert_eq!(iter.next(), Some(c2));
+    assert_eq!(iter.next_back(), Some(c3));
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next_back(), None);
+}
+
+#[test]
+fn detach_children_three_plus() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let c1 = root.append_value("c1", &mut arena);
+    let c2 = root.append_value("c2", &mut arena);
+    let c3 = root.append_value("c3", &mut arena);
+    let c4 = root.append_value("c4", &mut arena);
+
+    // Give c2 a subtree
+    let gc1 = c2.append_value("gc1", &mut arena);
+
+    root.detach_children(&mut arena);
+
+    assert_eq!(root.children(&arena).count(), 0);
+    assert!(root.first_child(&arena).is_none());
+    assert!(root.last_child(&arena).is_none());
+
+    // All children are detached
+    for &child in &[c1, c2, c3, c4] {
+        assert!(child.parent(&arena).is_none());
+        assert!(child.next_sibling(&arena).is_none());
+        assert!(child.previous_sibling(&arena).is_none());
+        assert!(!child.is_removed(&arena));
+    }
+
+    // Subtrees are preserved
+    assert_eq!(gc1.parent(&arena), Some(c2));
+    assert_eq!(c2.first_child(&arena), Some(gc1));
+}
+
+#[test]
+fn nodeid_convenience_accessors() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let c1 = root.append_value("c1", &mut arena);
+    let c2 = root.append_value("c2", &mut arena);
+
+    assert_eq!(root.first_child(&arena), Some(c1));
+    assert_eq!(root.last_child(&arena), Some(c2));
+    assert_eq!(c1.next_sibling(&arena), Some(c2));
+    assert_eq!(c2.previous_sibling(&arena), Some(c1));
+    assert_eq!(c1.previous_sibling(&arena), None);
+    assert_eq!(c2.next_sibling(&arena), None);
+}
+
+#[test]
+fn nodeid_predicates() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = root.append_value("child", &mut arena);
+
+    assert!(root.is_root(&arena));
+    assert!(!child.is_root(&arena));
+    assert!(root.has_children(&arena));
+    assert!(!child.has_children(&arena));
+    assert!(!root.is_leaf(&arena));
+    assert!(child.is_leaf(&arena));
+}
+
+#[test]
+fn arena_live_count() {
+    let mut arena = Arena::new();
+    assert_eq!(arena.live_count(), 0);
+
+    let n1 = arena.new_node("a");
+    arena.new_node("b");
+    arena.new_node("c");
+    assert_eq!(arena.live_count(), 3);
+    assert_eq!(arena.len(), 3);
+
+    n1.remove(&mut arena);
+    assert_eq!(arena.live_count(), 2);
+    assert_eq!(arena.len(), 3);
+}
+
+#[test]
+fn arena_shrink_to_fit() {
+    let mut arena: Arena<i32> = Arena::with_capacity(100);
+    assert!(arena.capacity() >= 100);
+
+    arena.new_node(1);
+    arena.new_node(2);
+    arena.shrink_to_fit();
+    // After shrinking, capacity should be close to len
+    assert!(arena.capacity() < 100);
+    assert!(arena.capacity() >= 2);
+}
+
+#[test]
+fn arena_into_iterator_owned() {
+    let mut arena = Arena::new();
+    arena.new_node(1);
+    arena.new_node(2);
+    arena.new_node(3);
+
+    let values: Vec<_> = arena.into_iter().map(|n| *n.get()).collect();
+    assert_eq!(values, vec![1, 2, 3]);
+}


### PR DESCRIPTION
- Add `NodeId` convenience accessors (`first_child()`, `last_child()`, `next_sibling()`, `previous_sibling()`) and predicates (`has_children()`, `is_leaf()`, `is_root()`)
- Add `Arena::shrink_to_fit()`, `Arena::live_count()`, and owned `IntoIterator` for `Arena<T>`
- Rewrite `Descendants` iterator to walk the tree directly instead of filtering `Traverse` Start/End edges (avoids 2x edge processing overhead)
- Optimize `detach_children` to clear links in a single pass instead of per-child `detach()` with redundant sibling fixup
- Narrow `clippy::redundant_closure_call` allow from module-level to the generated impl blocks only
- Restrict `NodeStamp` methods to `pub(crate)` (struct is already `pub(crate)`)
- Document the `arena[id]` stamp-bypass footgun on `Index`/`IndexMut` impls
- Add cross-reference from `iter()` docs to `iter_node_ids()`
- Add `#[warn(missing_docs)]` and fill in missing doc examples for `Arena` and `Node` methods
- Add tests: serde round-trip with free list, `par_iter_mut`, `remove_subtree` on root, interleaved `DoubleEndedIterator`, `detach_children` with 3+ children, convenience accessors/predicates, `live_count`, `shrink_to_fit`, owned `IntoIterator`
- Add `rust-version` to `indextree-macros` Cargo.toml
- Add `cargo-semver-checks` CI job
- Bump version to 4.9.0