### PR TITLE
Improve API, correctness, tests, and project config

### DIFF
--- a/.github/grcov.yml
+++ b/.github/grcov.yml
@@ -1,7 +1,0 @@
-branch: true
-ignore-not-existing: true
-llvm: true
-filter: covered
-output-type: lcov
-output-path: ./lcov.info
-prefix-dir: /home/user/build/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "indextree",
     "indextree-macros",

--- a/indextree-macros/tests/regular_usage.rs
+++ b/indextree-macros/tests/regular_usage.rs
@@ -90,3 +90,35 @@ fn mild_nesting() {
 
     compare_nodes(&arena, root_proc, root_macro);
 }
+
+#[test]
+fn integer_values() {
+    let mut arena = Arena::new();
+
+    let root_macro = tree! {
+        &mut arena,
+        0i32 => {
+            1,
+            2 => { 3 },
+            4,
+        }
+    };
+
+    let root_proc = arena.new_node(0i32);
+    root_proc.append_value(1, &mut arena);
+    let node_2 = root_proc.append_value(2, &mut arena);
+    node_2.append_value(3, &mut arena);
+    root_proc.append_value(4, &mut arena);
+
+    compare_nodes(&arena, root_proc, root_macro);
+}
+
+#[test]
+fn single_leaf_node() {
+    let mut arena: Arena<&str> = Arena::new();
+
+    let leaf = tree!(&mut arena, "lonely");
+
+    assert_eq!(*arena[leaf].get(), "lonely");
+    assert_eq!(leaf.children(&arena).count(), 0);
+}

--- a/indextree/src/arena.rs
+++ b/indextree/src/arena.rs
@@ -43,8 +43,12 @@ pub struct Arena<T> {
 impl<T> Arena<T> {
     /// Creates a new empty `Arena`.
     #[must_use]
-    pub fn new() -> Arena<T> {
-        Self::default()
+    pub const fn new() -> Arena<T> {
+        Self {
+            nodes: Vec::new(),
+            first_free_slot: None,
+            last_free_slot: None,
+        }
     }
 
     /// Creates a new empty `Arena` with enough capacity to store `n` nodes.
@@ -416,6 +420,27 @@ impl<T> Arena<T> {
         self.nodes.iter_mut()
     }
 
+    /// Returns an iterator of [`NodeId`]s of all root nodes (nodes with
+    /// no parent) that are not removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let a = arena.new_node("a");
+    /// let b = arena.new_node("b");
+    /// let c = arena.new_node("c");
+    /// a.append(c, &mut arena);
+    ///
+    /// let roots: Vec<_> = arena.roots().collect();
+    /// assert_eq!(roots, vec![a, b]);
+    /// ```
+    pub fn roots(&self) -> impl Iterator<Item = NodeId> + '_ {
+        self.iter_node_ids()
+            .filter(|&id| self[id].parent().is_none())
+    }
+
     /// Shrinks the internal storage to fit the current number of nodes.
     ///
     /// Calls [`Vec::shrink_to_fit`] on the underlying node storage.
@@ -611,6 +636,22 @@ impl<'a, T> IntoIterator for &'a mut Arena<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter_mut()
+    }
+}
+
+impl<T> Extend<T> for Arena<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for item in iter {
+            self.new_node(item);
+        }
+    }
+}
+
+impl<T> core::iter::FromIterator<T> for Arena<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut arena = Arena::new();
+        arena.extend(iter);
+        arena
     }
 }
 

--- a/indextree/src/id.rs
+++ b/indextree/src/id.rs
@@ -1572,19 +1572,21 @@ impl NodeId {
     pub fn remove_subtree<T>(self, arena: &mut Arena<T>) {
         self.detach(arena);
 
-        // Preorder traversal to remove all nodes. After free_node(id), we
-        // still read arena[id]'s link fields (first_child, next_sibling).
-        // This works because free_node only changes data to NextFree and
-        // the stamp; it does not clear structural link fields.
         let mut cursor = Some(self);
         while let Some(id) = cursor {
+            let first_child = arena[id].first_child;
+            let next_sibling = arena[id].next_sibling;
+            let parent = arena[id].parent;
             arena.free_node(id);
-            let node = &arena[id];
-            cursor = node.first_child.or(node.next_sibling).or_else(|| {
-                id.ancestors(arena) // traverse ancestors upwards
-                    .skip(1) // skip the starting node itself
-                    .find(|n| arena[*n].next_sibling.is_some()) // first ancestor with a sibling
-                    .and_then(|n| arena[n].next_sibling) // the sibling is the new cursor
+            cursor = first_child.or(next_sibling).or_else(|| {
+                let mut ancestor = parent;
+                while let Some(a) = ancestor {
+                    if let Some(sib) = arena[a].next_sibling {
+                        return Some(sib);
+                    }
+                    ancestor = arena[a].parent;
+                }
+                None
             });
         }
     }
@@ -1686,12 +1688,62 @@ impl NodeId {
     ///
     /// [`remove_subtree`]: NodeId::remove_subtree
     pub fn remove_children<T>(self, arena: &mut Arena<T>) {
-        let mut child_opt = arena[self].first_child;
-        while let Some(child) = child_opt {
-            let next = arena[child].next_sibling;
-            child.remove_subtree(arena);
-            child_opt = next;
+        let first = arena[self].first_child.take();
+        arena[self].last_child = None;
+
+        let mut cursor = first;
+        while let Some(id) = cursor {
+            let first_child = arena[id].first_child;
+            let next_sibling = arena[id].next_sibling;
+            let parent = arena[id].parent;
+            arena.free_node(id);
+            cursor = first_child.or(next_sibling).or_else(|| {
+                let mut ancestor = parent;
+                while let Some(a) = ancestor {
+                    if a == self {
+                        return None;
+                    }
+                    if let Some(sib) = arena[a].next_sibling {
+                        return Some(sib);
+                    }
+                    ancestor = arena[a].parent;
+                }
+                None
+            });
         }
+    }
+
+    /// Moves this node (and its subtree) to become the last child of
+    /// `new_parent`.
+    ///
+    /// This is a convenience wrapper around [`detach`] followed by
+    /// [`append`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_parent` is `self` or a descendant of `self`, or
+    /// if either node has been removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let a = arena.new_node("a");
+    /// let b = a.append_value("b", &mut arena);
+    /// let c = arena.new_node("c");
+    ///
+    /// b.reparent(c, &mut arena);
+    ///
+    /// assert_eq!(b.parent(&arena), Some(c));
+    /// assert_eq!(a.children(&arena).count(), 0);
+    /// assert_eq!(c.first_child(&arena), Some(b));
+    /// ```
+    ///
+    /// [`detach`]: NodeId::detach
+    /// [`append`]: NodeId::append
+    pub fn reparent<T>(self, new_parent: NodeId, arena: &mut Arena<T>) {
+        new_parent.append(self, arena);
     }
 
     /// Returns the pretty-printable proxy object to the node and descendants.

--- a/indextree/src/node.rs
+++ b/indextree/src/node.rs
@@ -131,6 +131,30 @@ impl<T> Node<T> {
         }
     }
 
+    /// Consumes the node and returns the contained data, or `None` if
+    /// the node has been removed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// arena.new_node(42);
+    /// arena.new_node(99);
+    ///
+    /// let values: Vec<_> = arena
+    ///     .into_iter()
+    ///     .filter_map(|n| n.into_data())
+    ///     .collect();
+    /// assert_eq!(values, vec![42, 99]);
+    /// ```
+    pub fn into_data(self) -> Option<T> {
+        match self.data {
+            NodeData::Data(data) => Some(data),
+            NodeData::NextFree(_) => None,
+        }
+    }
+
     /// Creates a new `Node` with the default state and the given data.
     pub(crate) fn new(data: T) -> Self {
         Self {

--- a/indextree/tests/lib.rs
+++ b/indextree/tests/lib.rs
@@ -1149,3 +1149,189 @@ fn arena_into_iterator_owned() {
     let values: Vec<_> = arena.into_iter().map(|n| *n.get()).collect();
     assert_eq!(values, vec![1, 2, 3]);
 }
+
+#[test]
+fn descendants_single_node() {
+    let mut arena = Arena::new();
+    let leaf = arena.new_node("leaf");
+
+    let mut iter = leaf.descendants(&arena);
+    assert_eq!(iter.next(), Some(leaf));
+    assert_eq!(iter.next(), None);
+    // FusedIterator: stays None
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn descendants_subtree_root() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let a = root.append_value("a", &mut arena);
+    let b = a.append_value("b", &mut arena);
+    let c = a.append_value("c", &mut arena);
+    root.append_value("d", &mut arena);
+
+    let sub: Vec<_> = a.descendants(&arena).collect();
+    assert_eq!(sub, vec![a, b, c]);
+}
+
+#[test]
+fn fused_iterators() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let c1 = root.append_value("c1", &mut arena);
+
+    let mut children = root.children(&arena);
+    assert_eq!(children.next(), Some(c1));
+    assert_eq!(children.next(), None);
+    assert_eq!(children.next(), None);
+
+    let mut ancestors = c1.ancestors(&arena);
+    assert_eq!(ancestors.next(), Some(c1));
+    assert_eq!(ancestors.next(), Some(root));
+    assert_eq!(ancestors.next(), None);
+    assert_eq!(ancestors.next(), None);
+
+    let mut siblings = c1.following_siblings(&arena);
+    assert_eq!(siblings.next(), Some(c1));
+    assert_eq!(siblings.next(), None);
+    assert_eq!(siblings.next(), None);
+}
+
+#[test]
+fn clear_then_reuse() {
+    let mut arena = Arena::new();
+    let a = arena.new_node("a");
+    let b = arena.new_node("b");
+    a.append(b, &mut arena);
+    arena.new_node("c");
+
+    arena.clear();
+    assert!(arena.is_empty());
+    assert_eq!(arena.len(), 0);
+
+    let d = arena.new_node("d");
+    let e = arena.new_node("e");
+    d.append(e, &mut arena);
+
+    assert_eq!(arena.len(), 2);
+    assert_eq!(*arena[d].get(), "d");
+    assert_eq!(arena[e].parent(), Some(d));
+}
+
+#[test]
+fn remove_children_single_child() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let only = root.append_value("only", &mut arena);
+    let gc = only.append_value("gc", &mut arena);
+
+    root.remove_children(&mut arena);
+
+    assert_eq!(root.children(&arena).count(), 0);
+    assert!(only.is_removed(&arena));
+    assert!(gc.is_removed(&arena));
+}
+
+#[test]
+fn detach_on_root_is_noop() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = root.append_value("child", &mut arena);
+
+    root.detach(&mut arena);
+
+    assert!(root.parent(&arena).is_none());
+    assert_eq!(root.first_child(&arena), Some(child));
+}
+
+#[test]
+fn arena_extend_and_from_iterator() {
+    let arena: Arena<i32> = (1..=5).collect();
+    assert_eq!(arena.len(), 5);
+
+    let values: Vec<_> = arena.iter().map(|n| *n.get()).collect();
+    assert_eq!(values, vec![1, 2, 3, 4, 5]);
+
+    let mut arena2 = Arena::new();
+    arena2.new_node(0);
+    arena2.extend(10..=12);
+    assert_eq!(arena2.len(), 4);
+}
+
+#[test]
+fn arena_roots() {
+    let mut arena = Arena::new();
+    let a = arena.new_node("a");
+    let b = arena.new_node("b");
+    let c = arena.new_node("c");
+    a.append(c, &mut arena);
+
+    let roots: Vec<_> = arena.roots().collect();
+    assert_eq!(roots, vec![a, b]);
+}
+
+#[test]
+fn node_into_data() {
+    let mut arena = Arena::new();
+    arena.new_node(String::from("hello"));
+    let id = arena.new_node(String::from("world"));
+    id.remove(&mut arena);
+
+    let data: Vec<_> = arena.into_iter().filter_map(|n| n.into_data()).collect();
+    assert_eq!(data, vec!["hello"]);
+}
+
+#[test]
+fn reparent_node() {
+    let mut arena = Arena::new();
+    let a = arena.new_node("a");
+    let b = a.append_value("b", &mut arena);
+    let c = arena.new_node("c");
+
+    b.reparent(c, &mut arena);
+
+    assert_eq!(b.parent(&arena), Some(c));
+    assert_eq!(a.children(&arena).count(), 0);
+    assert_eq!(c.first_child(&arena), Some(b));
+}
+
+#[test]
+fn remove_children_preserves_parent() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let parent = arena.new_node("parent");
+    root.append(parent, &mut arena);
+    let c1 = parent.append_value("c1", &mut arena);
+    let c2 = parent.append_value("c2", &mut arena);
+    let gc = c1.append_value("gc", &mut arena);
+
+    parent.remove_children(&mut arena);
+
+    assert_eq!(parent.parent(&arena), Some(root));
+    assert_eq!(parent.children(&arena).count(), 0);
+    assert!(c1.is_removed(&arena));
+    assert!(c2.is_removed(&arena));
+    assert!(gc.is_removed(&arena));
+}
+
+#[test]
+fn remove_children_deep_tree() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let c1 = root.append_value("c1", &mut arena);
+    let gc1 = c1.append_value("gc1", &mut arena);
+    let ggc1 = gc1.append_value("ggc1", &mut arena);
+    let gc2 = c1.append_value("gc2", &mut arena);
+    let c2 = root.append_value("c2", &mut arena);
+    let c3 = root.append_value("c3", &mut arena);
+    let gc3 = c3.append_value("gc3", &mut arena);
+
+    root.remove_children(&mut arena);
+
+    assert_eq!(root.children(&arena).count(), 0);
+    assert!(!root.is_removed(&arena));
+    for &id in &[c1, gc1, ggc1, gc2, c2, c3, gc3] {
+        assert!(id.is_removed(&arena));
+    }
+}


### PR DESCRIPTION
- Make `Arena::new()` `const fn`
- Add `Extend<T>` and `FromIterator<T>` for `Arena`
- Add `Arena::roots()` iterator for top-level nodes
- Add `Node::into_data()` for owned data extraction
- Add `NodeId::reparent()` convenience method
- Fix `remove_subtree` to extract links before `free_node`
- Optimize `remove_children` to single-pass DFS free
- Add tests: descendants single node and subtree root, fused iterators, clear-then-reuse, remove_children (single child, deep tree, preserves parent), detach on root, extend/from_iterator, roots, into_data, reparent
- Add `tree!` macro tests for integer types and single leaf
- Upgrade workspace resolver to 3
- Remove stale `.github/grcov.yml`