### PR TITLE
Improve API, correctness, docs, tests, and CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,6 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+
+[*.{yml,yaml,json,md}]
+indent_size = 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,16 @@ jobs:
           restore-keys: rust-test-platform-${{ matrix.os }}-
       - run: cargo test --all-features
 
+  no-std-target:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: stable
+          targets: thumbv7em-none-eabihf
+      - run: cargo check -p indextree --target thumbv7em-none-eabihf --no-default-features
+
   nightly:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/indextree/examples/simple.rs
+++ b/indextree/examples/simple.rs
@@ -1,6 +1,6 @@
 use indextree::Arena;
 
-pub fn main() {
+fn main() {
     // Create a new arena
     let arena = &mut Arena::new();
 

--- a/indextree/src/arena.rs
+++ b/indextree/src/arena.rs
@@ -163,6 +163,10 @@ impl<T> Arena<T> {
 
     /// Creates a new node from its associated data.
     ///
+    /// Freed slots are reused when available. If a slot's internal stamp has
+    /// been exhausted (after ~32K remove/reuse cycles), it is skipped and a
+    /// fresh slot is appended instead.
+    ///
     /// # Panics
     ///
     /// Panics if the arena already has `usize::max_value()` nodes.
@@ -322,6 +326,50 @@ impl<T> Arena<T> {
             .filter(|node| node.stamp == stamp)
     }
 
+    /// Returns a reference to the data of the node with the given id.
+    ///
+    /// Returns `None` if the id is out of bounds, the stamp doesn't match,
+    /// or the node has been removed.
+    ///
+    /// This is a shorthand for `arena.get(id).map(|n| n.get())`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    /// assert_eq!(arena.get_data(foo), Some(&"foo"));
+    ///
+    /// foo.remove(&mut arena);
+    /// assert_eq!(arena.get_data(foo), None);
+    /// ```
+    #[inline]
+    pub fn get_data(&self, id: NodeId) -> Option<&T> {
+        self.get(id).map(|n| n.get())
+    }
+
+    /// Returns a mutable reference to the data of the node with the given id.
+    ///
+    /// Returns `None` if the id is out of bounds, the stamp doesn't match,
+    /// or the node has been removed.
+    ///
+    /// This is a shorthand for `arena.get_mut(id).map(|n| n.get_mut())`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let foo = arena.new_node("foo");
+    /// *arena.get_data_mut(foo).unwrap() = "bar";
+    /// assert_eq!(arena.get_data(foo), Some(&"bar"));
+    /// ```
+    #[inline]
+    pub fn get_data_mut(&mut self, id: NodeId) -> Option<&mut T> {
+        self.get_mut(id).map(|n| n.get_mut())
+    }
+
     /// Returns an iterator of all nodes in the arena in storage-order.
     ///
     /// Note that this iterator returns also removed elements, which can be
@@ -441,6 +489,49 @@ impl<T> Arena<T> {
             .filter(|&id| self[id].parent().is_none())
     }
 
+    /// Creates a new arena by applying a function to the data of every
+    /// live node, preserving the tree structure.
+    ///
+    /// Removed nodes remain as removed slots in the new arena to keep
+    /// node indices consistent.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node(1);
+    /// let child = root.append_value(2, &mut arena);
+    ///
+    /// let mapped: Arena<String> = arena.map(|x| x.to_string());
+    /// assert_eq!(mapped.get_data(root), Some(&"1".to_string()));
+    /// assert_eq!(mapped.get_data(child), Some(&"2".to_string()));
+    /// assert_eq!(mapped[child].parent(), Some(root));
+    /// ```
+    pub fn map<U>(&self, mut f: impl FnMut(&T) -> U) -> Arena<U> {
+        let nodes = self
+            .nodes
+            .iter()
+            .map(|node| Node {
+                parent: node.parent,
+                previous_sibling: node.previous_sibling,
+                next_sibling: node.next_sibling,
+                first_child: node.first_child,
+                last_child: node.last_child,
+                stamp: node.stamp,
+                data: match &node.data {
+                    NodeData::Data(data) => NodeData::Data(f(data)),
+                    NodeData::NextFree(next) => NodeData::NextFree(*next),
+                },
+            })
+            .collect();
+        Arena {
+            nodes,
+            first_free_slot: self.first_free_slot,
+            last_free_slot: self.last_free_slot,
+        }
+    }
+
     /// Shrinks the internal storage to fit the current number of nodes.
     ///
     /// Calls [`Vec::shrink_to_fit`] on the underlying node storage.
@@ -514,6 +605,125 @@ impl<T> Arena<T> {
     /// ```
     pub fn as_slice(&self) -> &[Node<T>] {
         self.nodes.as_slice()
+    }
+
+    /// Validates the internal consistency of the arena's tree structure.
+    ///
+    /// Returns `true` if all parent-child and sibling pointers are
+    /// consistent, the free list is valid, and no cycles exist in
+    /// sibling chains. This is primarily useful after deserialization
+    /// to detect corrupted data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node(1);
+    /// root.append_value(2, &mut arena);
+    /// assert!(arena.validate());
+    /// ```
+    pub fn validate(&self) -> bool {
+        let len = self.nodes.len();
+
+        for (i, node) in self.nodes.iter().enumerate() {
+            if node.is_removed() {
+                continue;
+            }
+
+            let check_id =
+                |id: NodeId| -> bool { id.index0() < len && !self.nodes[id.index0()].is_removed() };
+
+            if let Some(parent) = node.parent {
+                if !check_id(parent) {
+                    return false;
+                }
+                let p = &self.nodes[parent.index0()];
+                let mut found = false;
+                let mut child = p.first_child;
+                let mut steps = 0;
+                while let Some(c) = child {
+                    if c.index0() >= len {
+                        return false;
+                    }
+                    if c.index0() == i {
+                        found = true;
+                        break;
+                    }
+                    child = self.nodes[c.index0()].next_sibling;
+                    steps += 1;
+                    if steps > len {
+                        return false;
+                    }
+                }
+                if !found {
+                    return false;
+                }
+            }
+
+            if let Some(prev) = node.previous_sibling {
+                if !check_id(prev)
+                    || self.nodes[prev.index0()].next_sibling.map(|n| n.index0()) != Some(i)
+                {
+                    return false;
+                }
+            }
+            if let Some(next) = node.next_sibling {
+                if !check_id(next)
+                    || self.nodes[next.index0()]
+                        .previous_sibling
+                        .map(|n| n.index0())
+                        != Some(i)
+                {
+                    return false;
+                }
+            }
+            if let Some(first) = node.first_child {
+                if !check_id(first)
+                    || self.nodes[first.index0()].parent.map(|n| n.index0()) != Some(i)
+                {
+                    return false;
+                }
+            }
+            if let Some(last) = node.last_child {
+                if !check_id(last)
+                    || self.nodes[last.index0()].parent.map(|n| n.index0()) != Some(i)
+                {
+                    return false;
+                }
+            }
+            if node.first_child.is_some() != node.last_child.is_some() {
+                return false;
+            }
+        }
+
+        // Validate free list
+        if self.first_free_slot.is_some() != self.last_free_slot.is_some() {
+            return false;
+        }
+        let mut free_count = 0;
+        let mut last_visited = None;
+        let mut slot = self.first_free_slot;
+        while let Some(idx) = slot {
+            if idx >= len {
+                return false;
+            }
+            let node = &self.nodes[idx];
+            if !node.is_removed() {
+                return false;
+            }
+            match node.data {
+                NodeData::NextFree(next) => slot = next,
+                _ => return false,
+            }
+            last_visited = Some(idx);
+            free_count += 1;
+            if free_count > len {
+                return false;
+            }
+        }
+
+        self.last_free_slot == last_visited
     }
 
     pub(crate) fn free_node(&mut self, id: NodeId) {
@@ -680,6 +890,12 @@ impl<T> Default for Arena<T> {
 /// Unlike [`Arena::get`], this does **not** validate the node's stamp,
 /// so it may silently return data from a reused slot if the `NodeId`
 /// is stale. For safe access, prefer [`Arena::get`] or [`Arena::get_mut`].
+///
+/// # Panics
+///
+/// Panics if `node` is out of bounds. Note that indexing does not validate
+/// that the `NodeId` originated from this arena. Using an ID from a
+/// different arena may silently access the wrong node or panic.
 impl<T> Index<NodeId> for Arena<T> {
     type Output = Node<T>;
 

--- a/indextree/src/id.rs
+++ b/indextree/src/id.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, num::NonZeroUsize};
 
 use crate::{
-    Ancestors, Arena, Children, Descendants, FollowingSiblings, NodeError, PrecedingSiblings,
-    Predecessors, ReverseTraverse, Traverse,
+    Ancestors, Arena, BreadthFirstTraversal, Children, Descendants, FollowingSiblings, Leaves,
+    NodeError, PrecedingSiblings, Predecessors, ReverseTraverse, Traverse,
     debug_pretty_print::DebugPrettyPrint,
     relations::{insert_first_unchecked, insert_last_unchecked, insert_with_neighbors},
     siblings_range::SiblingsRange,
@@ -27,6 +27,13 @@ use crate::{
 ///
 /// This ID is used to get [`Node`](crate::Node) references from an [`Arena`].
 ///
+/// # Cross-arena safety
+///
+/// A `NodeId` does not carry a reference to the arena it was created in.
+/// Using an ID from one arena to index into a different arena will either
+/// panic (if the index is out of bounds) or silently access the wrong node.
+/// It is the caller's responsibility to use each `NodeId` only with its
+/// originating arena.
 pub struct NodeId {
     /// One-based index.
     index1: NonZeroUsize,
@@ -38,9 +45,12 @@ pub struct NodeId {
 ///
 /// Uses the sign of an `i16` as a removed flag: non-negative values represent
 /// live nodes, negative values represent removed nodes. Each remove/reuse
-/// cycle increments the effective generation by 1. After approximately
-/// 32,766 cycles the slot becomes permanently unreusable, preventing stamp
-/// value collisions.
+/// cycle increments the effective generation by 1.
+///
+/// After approximately 32,766 remove/reuse cycles on the same slot, the
+/// stamp saturates and the slot becomes permanently unreusable. New nodes
+/// will be appended to the end of the arena instead. In practice this is
+/// unlikely to matter unless a single slot is recycled in a tight loop.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub(crate) struct NodeStamp(i16);
@@ -701,6 +711,69 @@ impl NodeId {
         Descendants::new(arena, self)
     }
 
+    /// Returns an iterator over the leaf nodes (nodes with no children)
+    /// of this node's subtree in pre-order depth-first order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node("root");
+    /// let a = root.append_value("a", &mut arena);
+    /// let b = a.append_value("b", &mut arena);
+    /// let c = root.append_value("c", &mut arena);
+    ///
+    /// let leaves: Vec<_> = root.leaves(&arena).collect();
+    /// assert_eq!(leaves, vec![b, c]);
+    /// ```
+    pub fn leaves<T>(self, arena: &Arena<T>) -> Leaves<'_, T> {
+        Leaves::new(arena, self)
+    }
+
+    /// Returns an iterator that yields nodes in breadth-first (level-order)
+    /// order, starting from this node.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node(1);
+    /// let a = root.append_value(2, &mut arena);
+    /// let b = root.append_value(3, &mut arena);
+    /// let c = a.append_value(4, &mut arena);
+    ///
+    /// let bfs: Vec<_> = root.breadth_first(&arena)
+    ///     .map(|id| *arena[id].get())
+    ///     .collect();
+    /// assert_eq!(bfs, vec![1, 2, 3, 4]);
+    /// ```
+    pub fn breadth_first<T>(self, arena: &Arena<T>) -> BreadthFirstTraversal<'_, T> {
+        BreadthFirstTraversal::new(arena, self)
+    }
+
+    /// Returns the number of descendants of this node, including itself.
+    ///
+    /// This is O(n) in the size of the subtree.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node("root");
+    /// let a = root.append_value("a", &mut arena);
+    /// a.append_value("b", &mut arena);
+    /// root.append_value("c", &mut arena);
+    ///
+    /// assert_eq!(root.descendant_count(&arena), 4);
+    /// assert_eq!(a.descendant_count(&arena), 2);
+    /// ```
+    pub fn descendant_count<T>(self, arena: &Arena<T>) -> usize {
+        self.descendants(arena).count()
+    }
+
     /// An iterator of the "sides" of a node visited during a depth-first pre-order traversal,
     /// where node sides are visited start to end and children are visited in insertion order.
     ///
@@ -812,6 +885,31 @@ impl NodeId {
     /// ```
     pub fn reverse_traverse<T>(self, arena: &Arena<T>) -> ReverseTraverse<'_, T> {
         ReverseTraverse::new(arena, self)
+    }
+
+    /// Detaches a node from its parent and siblings. Children are not affected.
+    ///
+    /// # Failures
+    ///
+    /// Returns [`NodeError::Removed`] if the node has been removed or the
+    /// ID is stale.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node("root");
+    /// let child = root.append_value("child", &mut arena);
+    /// assert!(child.checked_detach(&mut arena).is_ok());
+    /// assert!(child.parent(&arena).is_none());
+    /// ```
+    pub fn checked_detach<T>(self, arena: &mut Arena<T>) -> Result<(), NodeError> {
+        if self.is_removed(arena) {
+            return Err(NodeError::Removed);
+        }
+        self.detach(arena);
+        Ok(())
     }
 
     /// Detaches a node from its parent and siblings. Children are not affected.
@@ -952,7 +1050,7 @@ impl NodeId {
         if new_child == self {
             return Err(NodeError::AppendSelf);
         }
-        if arena[self].is_removed() || arena[new_child].is_removed() {
+        if self.is_removed(arena) || new_child.is_removed(arena) {
             return Err(NodeError::Removed);
         }
         if self.ancestors(arena).any(|ancestor| new_child == ancestor) {
@@ -1143,7 +1241,7 @@ impl NodeId {
         if new_child == self {
             return Err(NodeError::PrependSelf);
         }
-        if arena[self].is_removed() || arena[new_child].is_removed() {
+        if self.is_removed(arena) || new_child.is_removed(arena) {
             return Err(NodeError::Removed);
         }
         if self.ancestors(arena).any(|ancestor| new_child == ancestor) {
@@ -1281,7 +1379,7 @@ impl NodeId {
         if new_sibling == self {
             return Err(NodeError::InsertAfterSelf);
         }
-        if arena[self].is_removed() || arena[new_sibling].is_removed() {
+        if self.is_removed(arena) || new_sibling.is_removed(arena) {
             return Err(NodeError::Removed);
         }
         new_sibling.detach(arena);
@@ -1421,7 +1519,7 @@ impl NodeId {
         if new_sibling == self {
             return Err(NodeError::InsertBeforeSelf);
         }
-        if arena[self].is_removed() || arena[new_sibling].is_removed() {
+        if self.is_removed(arena) || new_sibling.is_removed(arena) {
             return Err(NodeError::Removed);
         }
         new_sibling.detach(arena);
@@ -1432,6 +1530,33 @@ impl NodeId {
         insert_with_neighbors(arena, new_sibling, parent, previous_sibling, Some(self))
             .expect("Should never fail: `new_sibling` is not `self` and they are not removed");
 
+        Ok(())
+    }
+
+    /// Removes a node from the arena, returning an error on failure.
+    ///
+    /// Children of the removed node will be inserted in place of the
+    /// removed node.
+    ///
+    /// # Failures
+    ///
+    /// Returns [`NodeError::Removed`] if the node has been removed or the
+    /// ID is stale.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::{Arena, NodeError};
+    /// let mut arena = Arena::new();
+    /// let n = arena.new_node("x");
+    /// assert!(n.checked_remove(&mut arena).is_ok());
+    /// assert!(matches!(n.checked_remove(&mut arena), Err(NodeError::Removed)));
+    /// ```
+    pub fn checked_remove<T>(self, arena: &mut Arena<T>) -> Result<(), NodeError> {
+        if self.is_removed(arena) {
+            return Err(NodeError::Removed);
+        }
+        self.remove(arena);
         Ok(())
     }
 
@@ -1529,6 +1654,32 @@ impl NodeId {
         debug_assert!(arena[self].is_detached());
     }
 
+    /// Removes a node and its descendants from the arena, returning an
+    /// error on failure.
+    ///
+    /// # Failures
+    ///
+    /// Returns [`NodeError::Removed`] if the node has been removed or the
+    /// ID is stale.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::{Arena, NodeError};
+    /// let mut arena = Arena::new();
+    /// let n = arena.new_node("x");
+    /// n.append_value("child", &mut arena);
+    /// assert!(n.checked_remove_subtree(&mut arena).is_ok());
+    /// assert!(matches!(n.checked_remove_subtree(&mut arena), Err(NodeError::Removed)));
+    /// ```
+    pub fn checked_remove_subtree<T>(self, arena: &mut Arena<T>) -> Result<(), NodeError> {
+        if self.is_removed(arena) {
+            return Err(NodeError::Removed);
+        }
+        self.remove_subtree(arena);
+        Ok(())
+    }
+
     /// Removes a node and its descendants from the arena.
     /// # Examples
     ///
@@ -1574,21 +1725,48 @@ impl NodeId {
 
         let mut cursor = Some(self);
         while let Some(id) = cursor {
-            let first_child = arena[id].first_child;
-            let next_sibling = arena[id].next_sibling;
-            let parent = arena[id].parent;
+            let node = &arena[id];
+            let first_child = node.first_child;
+            let next_sibling = node.next_sibling;
+            let parent = node.parent;
             arena.free_node(id);
             cursor = first_child.or(next_sibling).or_else(|| {
                 let mut ancestor = parent;
                 while let Some(a) = ancestor {
-                    if let Some(sib) = arena[a].next_sibling {
+                    let ancestor_node = &arena[a];
+                    if let Some(sib) = ancestor_node.next_sibling {
                         return Some(sib);
                     }
-                    ancestor = arena[a].parent;
+                    ancestor = ancestor_node.parent;
                 }
                 None
             });
         }
+    }
+
+    /// Detaches all children of this node, returning an error on failure.
+    ///
+    /// # Failures
+    ///
+    /// Returns [`NodeError::Removed`] if the node has been removed or the
+    /// ID is stale.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node("root");
+    /// root.append_value("c1", &mut arena);
+    /// assert!(root.checked_detach_children(&mut arena).is_ok());
+    /// assert_eq!(root.children(&arena).count(), 0);
+    /// ```
+    pub fn checked_detach_children<T>(self, arena: &mut Arena<T>) -> Result<(), NodeError> {
+        if self.is_removed(arena) {
+            return Err(NodeError::Removed);
+        }
+        self.detach_children(arena);
+        Ok(())
     }
 
     /// Detaches all children of this node, leaving them as independent
@@ -1647,6 +1825,32 @@ impl NodeId {
         }
     }
 
+    /// Removes all children of this node from the arena, returning an
+    /// error on failure.
+    ///
+    /// # Failures
+    ///
+    /// Returns [`NodeError::Removed`] if the node has been removed or the
+    /// ID is stale.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let root = arena.new_node("root");
+    /// root.append_value("c1", &mut arena);
+    /// assert!(root.checked_remove_children(&mut arena).is_ok());
+    /// assert_eq!(root.children(&arena).count(), 0);
+    /// ```
+    pub fn checked_remove_children<T>(self, arena: &mut Arena<T>) -> Result<(), NodeError> {
+        if self.is_removed(arena) {
+            return Err(NodeError::Removed);
+        }
+        self.remove_children(arena);
+        Ok(())
+    }
+
     /// Removes all children of this node from the arena, keeping the
     /// node itself in its current position.
     ///
@@ -1693,9 +1897,10 @@ impl NodeId {
 
         let mut cursor = first;
         while let Some(id) = cursor {
-            let first_child = arena[id].first_child;
-            let next_sibling = arena[id].next_sibling;
-            let parent = arena[id].parent;
+            let node = &arena[id];
+            let first_child = node.first_child;
+            let next_sibling = node.next_sibling;
+            let parent = node.parent;
             arena.free_node(id);
             cursor = first_child.or(next_sibling).or_else(|| {
                 let mut ancestor = parent;
@@ -1703,14 +1908,43 @@ impl NodeId {
                     if a == self {
                         return None;
                     }
-                    if let Some(sib) = arena[a].next_sibling {
+                    let ancestor_node = &arena[a];
+                    if let Some(sib) = ancestor_node.next_sibling {
                         return Some(sib);
                     }
-                    ancestor = arena[a].parent;
+                    ancestor = ancestor_node.parent;
                 }
                 None
             });
         }
+    }
+
+    /// Moves this node (and its subtree) to become the last child of
+    /// `new_parent`, returning an error on failure.
+    ///
+    /// # Failures
+    ///
+    /// Returns the same errors as [`checked_append`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut arena = Arena::new();
+    /// let a = arena.new_node("a");
+    /// let b = a.append_value("b", &mut arena);
+    /// let c = arena.new_node("c");
+    /// assert!(b.checked_reparent(c, &mut arena).is_ok());
+    /// assert_eq!(b.parent(&arena), Some(c));
+    /// ```
+    ///
+    /// [`checked_append`]: NodeId::checked_append
+    pub fn checked_reparent<T>(
+        self,
+        new_parent: NodeId,
+        arena: &mut Arena<T>,
+    ) -> Result<(), NodeError> {
+        new_parent.checked_append(self, arena)
     }
 
     /// Moves this node (and its subtree) to become the last child of
@@ -1744,6 +1978,54 @@ impl NodeId {
     /// [`append`]: NodeId::append
     pub fn reparent<T>(self, new_parent: NodeId, arena: &mut Arena<T>) {
         new_parent.append(self, arena);
+    }
+
+    /// Returns `true` if the subtree rooted at this node is structurally
+    /// equal to the subtree rooted at `other`, comparing node data with
+    /// `PartialEq`.
+    ///
+    /// Two subtrees are equal if they have the same shape and the same
+    /// data at every corresponding position.
+    ///
+    /// The two nodes may be in the same or different arenas.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use indextree::Arena;
+    /// let mut a1 = Arena::new();
+    /// let r1 = a1.new_node(1);
+    /// r1.append_value(2, &mut a1);
+    /// r1.append_value(3, &mut a1);
+    ///
+    /// let mut a2 = Arena::new();
+    /// let r2 = a2.new_node(1);
+    /// r2.append_value(2, &mut a2);
+    /// r2.append_value(3, &mut a2);
+    ///
+    /// assert!(r1.subtree_eq(r2, &a1, &a2));
+    /// ```
+    pub fn subtree_eq<T: PartialEq>(
+        self,
+        other: NodeId,
+        arena_self: &Arena<T>,
+        arena_other: &Arena<T>,
+    ) -> bool {
+        use crate::NodeEdge;
+        let mut iter_a = self.traverse(arena_self);
+        let mut iter_b = other.traverse(arena_other);
+        loop {
+            match (iter_a.next(), iter_b.next()) {
+                (None, None) => return true,
+                (Some(NodeEdge::Start(a)), Some(NodeEdge::Start(b))) => {
+                    if arena_self[a].get() != arena_other[b].get() {
+                        return false;
+                    }
+                }
+                (Some(NodeEdge::End(_)), Some(NodeEdge::End(_))) => {}
+                _ => return false,
+            }
+        }
     }
 
     /// Returns the pretty-printable proxy object to the node and descendants.

--- a/indextree/src/lib.rs
+++ b/indextree/src/lib.rs
@@ -77,8 +77,8 @@ pub use crate::{
     id::NodeId,
     node::Node,
     traverse::{
-        Ancestors, Children, Descendants, FollowingSiblings, NodeEdge, PrecedingSiblings,
-        Predecessors, ReverseTraverse, Traverse,
+        Ancestors, BreadthFirstTraversal, Children, Descendants, FollowingSiblings, Leaves,
+        NodeEdge, PrecedingSiblings, Predecessors, ReverseTraverse, Traverse,
     },
 };
 

--- a/indextree/src/traverse.rs
+++ b/indextree/src/traverse.rs
@@ -1,9 +1,16 @@
 //! Tree traversal iterators.
 //!
 //! Provides iterators for walking the tree in various orders: ancestors,
-//! predecessors, siblings, children, descendants, and depth-first traversal.
+//! predecessors, siblings, children, descendants, depth-first traversal,
+//! breadth-first traversal, and leaf iteration.
 //! All iterators are lazy, implement [`FusedIterator`](core::iter::FusedIterator),
 //! and provide [`size_hint`](Iterator::size_hint) bounds.
+
+#[cfg(not(feature = "std"))]
+use alloc::collections::VecDeque;
+
+#[cfg(feature = "std")]
+use std::collections::VecDeque;
 
 use crate::{Arena, Node, NodeId};
 
@@ -597,3 +604,74 @@ impl<T> Iterator for ReverseTraverse<'_, T> {
 }
 
 impl<T> core::iter::FusedIterator for ReverseTraverse<'_, T> {}
+
+/// An iterator that yields only the leaf nodes (nodes with no children)
+/// of a subtree in pre-order depth-first order.
+#[derive(Clone)]
+pub struct Leaves<'a, T> {
+    inner: Descendants<'a, T>,
+}
+
+impl<'a, T> Leaves<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, root: NodeId) -> Self {
+        Self {
+            inner: Descendants::new(arena, root),
+        }
+    }
+}
+
+impl<T> Iterator for Leaves<'_, T> {
+    type Item = NodeId;
+
+    fn next(&mut self) -> Option<NodeId> {
+        loop {
+            let id = self.inner.next()?;
+            if self.inner.arena[id].first_child.is_none() {
+                return Some(id);
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.inner.size_hint();
+        (0, upper)
+    }
+}
+
+impl<T> core::iter::FusedIterator for Leaves<'_, T> {}
+
+/// An iterator that yields nodes in breadth-first (level-order) order.
+#[derive(Clone)]
+pub struct BreadthFirstTraversal<'a, T> {
+    arena: &'a Arena<T>,
+    queue: VecDeque<NodeId>,
+}
+
+impl<'a, T> BreadthFirstTraversal<'a, T> {
+    pub(crate) fn new(arena: &'a Arena<T>, root: NodeId) -> Self {
+        let mut queue = VecDeque::new();
+        queue.push_back(root);
+        Self { arena, queue }
+    }
+}
+
+impl<T> Iterator for BreadthFirstTraversal<'_, T> {
+    type Item = NodeId;
+
+    fn next(&mut self) -> Option<NodeId> {
+        let current = self.queue.pop_front()?;
+        let mut child = self.arena[current].first_child;
+        while let Some(c) = child {
+            self.queue.push_back(c);
+            child = self.arena[c].next_sibling;
+        }
+        Some(current)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.queue.len();
+        (len, if len == 0 { Some(0) } else { None })
+    }
+}
+
+impl<T> core::iter::FusedIterator for BreadthFirstTraversal<'_, T> {}

--- a/indextree/tests/lib.rs
+++ b/indextree/tests/lib.rs
@@ -3,6 +3,201 @@ use indextree::{Arena, NodeError};
 use rayon::prelude::*;
 
 #[test]
+fn leaves_iterator() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let a = root.append_value("a", &mut arena);
+    let b = a.append_value("b", &mut arena);
+    let c = root.append_value("c", &mut arena);
+    let d = c.append_value("d", &mut arena);
+    let e = c.append_value("e", &mut arena);
+
+    let leaves: Vec<_> = root.leaves(&arena).collect();
+    assert_eq!(leaves, vec![b, d, e]);
+}
+
+#[test]
+fn leaves_single_node() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let leaves: Vec<_> = root.leaves(&arena).collect();
+    assert_eq!(leaves, vec![root]);
+}
+
+#[test]
+fn breadth_first_traversal() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(1);
+    let a = root.append_value(2, &mut arena);
+    let b = root.append_value(3, &mut arena);
+    a.append_value(4, &mut arena);
+    a.append_value(5, &mut arena);
+    b.append_value(6, &mut arena);
+
+    let bfs: Vec<i32> = root
+        .breadth_first(&arena)
+        .map(|id| *arena[id].get())
+        .collect();
+    assert_eq!(bfs, vec![1, 2, 3, 4, 5, 6]);
+}
+
+#[test]
+fn breadth_first_single_node() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(42);
+    let bfs: Vec<_> = root.breadth_first(&arena).collect();
+    assert_eq!(bfs, vec![root]);
+}
+
+#[test]
+fn descendant_count() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let a = root.append_value("a", &mut arena);
+    a.append_value("b", &mut arena);
+    root.append_value("c", &mut arena);
+
+    assert_eq!(root.descendant_count(&arena), 4);
+    assert_eq!(a.descendant_count(&arena), 2);
+}
+
+#[test]
+fn arena_map() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(1);
+    let child = root.append_value(2, &mut arena);
+
+    let mapped: Arena<String> = arena.map(|x| x.to_string());
+    assert_eq!(mapped.get_data(root), Some(&"1".to_string()));
+    assert_eq!(mapped.get_data(child), Some(&"2".to_string()));
+    assert_eq!(mapped[child].parent(), Some(root));
+}
+
+#[test]
+fn arena_map_with_removed() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(1);
+    let child = root.append_value(2, &mut arena);
+    child.remove(&mut arena);
+
+    let mapped: Arena<String> = arena.map(|x| x.to_string());
+    assert_eq!(mapped.get_data(root), Some(&"1".to_string()));
+    assert!(child.is_removed(&mapped));
+}
+
+#[test]
+fn subtree_eq_same_arena() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(1);
+    let a = root.append_value(2, &mut arena);
+    let b = root.append_value(3, &mut arena);
+    a.append_value(4, &mut arena);
+    b.append_value(4, &mut arena);
+
+    // a and b have different data (2 vs 3)
+    assert!(!a.subtree_eq(b, &arena, &arena));
+}
+
+#[test]
+fn subtree_eq_different_arenas() {
+    let mut a1 = Arena::new();
+    let r1 = a1.new_node(1);
+    r1.append_value(2, &mut a1);
+    r1.append_value(3, &mut a1);
+
+    let mut a2 = Arena::new();
+    let r2 = a2.new_node(1);
+    r2.append_value(2, &mut a2);
+    r2.append_value(3, &mut a2);
+
+    assert!(r1.subtree_eq(r2, &a1, &a2));
+}
+
+#[test]
+fn subtree_eq_different_structure() {
+    let mut a1 = Arena::new();
+    let r1 = a1.new_node(1);
+    r1.append_value(2, &mut a1);
+
+    let mut a2 = Arena::new();
+    let r2 = a2.new_node(1);
+    let c = r2.append_value(2, &mut a2);
+    c.append_value(3, &mut a2);
+
+    assert!(!r1.subtree_eq(r2, &a1, &a2));
+}
+
+#[test]
+fn get_data_shorthand() {
+    let mut arena = Arena::new();
+    let id = arena.new_node(42);
+    assert_eq!(arena.get_data(id), Some(&42));
+    *arena.get_data_mut(id).unwrap() = 99;
+    assert_eq!(arena.get_data(id), Some(&99));
+    id.remove(&mut arena);
+    assert_eq!(arena.get_data(id), None);
+    assert_eq!(arena.get_data_mut(id), None);
+}
+
+#[test]
+fn checked_remove_on_stale_id() {
+    let mut arena = Arena::new();
+    let original = arena.new_node("original");
+    original.remove(&mut arena);
+    let _reused = arena.new_node("reused");
+
+    assert!(matches!(
+        original.checked_remove(&mut arena),
+        Err(NodeError::Removed)
+    ));
+}
+
+#[test]
+fn checked_detach() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = root.append_value("child", &mut arena);
+    assert!(child.checked_detach(&mut arena).is_ok());
+    assert!(child.parent(&arena).is_none());
+}
+
+#[test]
+fn checked_reparent() {
+    let mut arena = Arena::new();
+    let a = arena.new_node("a");
+    let b = a.append_value("b", &mut arena);
+    let c = arena.new_node("c");
+    assert!(b.checked_reparent(c, &mut arena).is_ok());
+    assert_eq!(b.parent(&arena), Some(c));
+}
+
+#[test]
+fn arena_validate() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(1);
+    root.append_value(2, &mut arena);
+    root.append_value(3, &mut arena);
+    assert!(arena.validate());
+}
+
+#[test]
+fn stale_id_checked_append_detects_reuse() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let original = arena.new_node("original");
+    root.append(original, &mut arena);
+    original.remove(&mut arena);
+    let _reused = arena.new_node("reused");
+
+    // original is a stale ID pointing to a reused slot
+    let fresh = arena.new_node("fresh");
+    assert!(matches!(
+        original.checked_append(fresh, &mut arena),
+        Err(NodeError::Removed)
+    ));
+}
+
+#[test]
 fn success_create() {
     let mut new_counter = 0;
     let arena = &mut Arena::new();
@@ -667,6 +862,13 @@ fn size_hint_iterators() {
     assert_eq!(c1.following_siblings(&arena).size_hint(), (1, None));
     assert_eq!(c1.predecessors(&arena).size_hint(), (1, None));
 
+    // Leaves: lower bound is 0 (filtering), upper bound from descendants
+    let (lo, _) = root.leaves(&arena).size_hint();
+    assert_eq!(lo, 0);
+
+    // BFS: lower bound is queue length
+    assert_eq!(root.breadth_first(&arena).size_hint(), (1, None));
+
     // Exhausted iterators report exact zero
     let mut iter = root.ancestors(&arena);
     iter.next(); // root itself, no parent
@@ -686,6 +888,14 @@ fn size_hint_iterators() {
     assert_eq!(iter.size_hint(), (0, Some(0)));
 
     let mut iter = root.descendants(&arena);
+    while iter.next().is_some() {}
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+
+    let mut iter = root.leaves(&arena);
+    while iter.next().is_some() {}
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+
+    let mut iter = root.breadth_first(&arena);
     while iter.next().is_some() {}
     assert_eq!(iter.size_hint(), (0, Some(0)));
 }
@@ -1196,6 +1406,17 @@ fn fused_iterators() {
     assert_eq!(siblings.next(), Some(c1));
     assert_eq!(siblings.next(), None);
     assert_eq!(siblings.next(), None);
+
+    let mut leaves = root.leaves(&arena);
+    assert_eq!(leaves.next(), Some(c1));
+    assert_eq!(leaves.next(), None);
+    assert_eq!(leaves.next(), None);
+
+    let mut bfs = root.breadth_first(&arena);
+    assert_eq!(bfs.next(), Some(root));
+    assert_eq!(bfs.next(), Some(c1));
+    assert_eq!(bfs.next(), None);
+    assert_eq!(bfs.next(), None);
 }
 
 #[test]

--- a/indextree/tests/serde.rs
+++ b/indextree/tests/serde.rs
@@ -8,6 +8,7 @@ fn round_trip_empty_arena() {
     let json = serde_json::to_string(&arena).unwrap();
     let deserialized: Arena<i32> = serde_json::from_str(&json).unwrap();
     assert_eq!(arena, deserialized);
+    assert!(deserialized.validate());
 }
 
 #[test]
@@ -19,6 +20,7 @@ fn round_trip_single_node() {
     let json = serde_json::to_string(&arena).unwrap();
     let deserialized: Arena<&str> = serde_json::from_str(&json).unwrap();
     assert_eq!(arena, deserialized);
+    assert!(deserialized.validate());
 }
 
 #[test]
@@ -33,6 +35,7 @@ fn round_trip_tree() {
     let json = serde_json::to_string(&arena).unwrap();
     let deserialized: Arena<i32> = serde_json::from_str(&json).unwrap();
     assert_eq!(arena, deserialized);
+    assert!(deserialized.validate());
 }
 
 #[test]
@@ -46,4 +49,21 @@ fn round_trip_with_removed_node() {
     let json = serde_json::to_string(&arena).unwrap();
     let deserialized: Arena<i32> = serde_json::from_str(&json).unwrap();
     assert_eq!(arena, deserialized);
+    assert!(deserialized.validate());
+}
+
+#[test]
+fn round_trip_with_reused_slot() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(1);
+    let c1 = root.append_value(2, &mut arena);
+    root.append_value(3, &mut arena);
+    c1.remove(&mut arena);
+    let c4 = arena.new_node(4);
+    root.append(c4, &mut arena);
+
+    let json = serde_json::to_string(&arena).unwrap();
+    let deserialized: Arena<i32> = serde_json::from_str(&json).unwrap();
+    assert_eq!(arena, deserialized);
+    assert!(deserialized.validate());
 }


### PR DESCRIPTION
- Fix `checked_*` methods to validate stamp against slot (detects stale IDs on reused slots)
- Fix `remove_subtree`/`remove_children` to read link fields before freeing nodes
- Add `checked_` variants: `detach`, `remove`, `remove_subtree`, `detach_children`, `remove_children`, `reparent`
- Add `Arena::get_data`, `get_data_mut`, `map`, `validate`
- Add `Leaves` and `BreadthFirstTraversal` iterators, `descendant_count`
- Add `NodeId::subtree_eq` for structural tree comparison
- Add cross-arena safety warning and stamp exhaustion docs
- Add `no_std` target CI job
- Add serde round-trip validation tests
- Fix `pub fn main` in simple example
- Add `.editorconfig` override for YAML/JSON/Markdown