### PR TITLE
Improve correctness, performance, docs, tests, and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,14 @@ jobs:
         with:
           toolchain: stable
           targets: thumbv7em-none-eabihf
+      - run: cargo generate-lockfile
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            target
+            ~/.cargo/registry
+          key: rust-no-std-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-no-std-target-
       - run: cargo check -p indextree --target thumbv7em-none-eabihf --no-default-features
 
   nightly:
@@ -171,6 +179,19 @@ jobs:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        with:
+          toolchain: stable
+      - run: cargo generate-lockfile
+      - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
+        with:
+          tool: cargo-deny
+      - run: cargo deny check
 
   semver:
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,9 @@
+[licenses]
+allow = ["MIT", "Apache-2.0", "Unicode-3.0"]
+
+[bans]
+multiple-versions = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/indextree/src/arena.rs
+++ b/indextree/src/arena.rs
@@ -613,10 +613,25 @@ impl<T> Arena<T> {
 
     /// Validates the internal consistency of the arena's tree structure.
     ///
-    /// Returns `true` if all parent-child and sibling pointers are
-    /// consistent, the free list is valid, and no cycles exist in
-    /// sibling chains. This is primarily useful after deserialization
-    /// to detect corrupted data.
+    /// Returns `true` if the arena passes all of the following checks:
+    ///
+    /// - Every live node contains actual data (not a free-list entry).
+    /// - Parent, previous/next sibling, and first/last child pointers
+    ///   all refer to valid, non-removed nodes with matching stamps.
+    /// - `first_child` and `last_child` are both set or both unset.
+    /// - Sibling back-pointers are reciprocal (prev's next == self,
+    ///   next's prev == self).
+    /// - Every child in a parent's child chain points back to that
+    ///   parent, and the chain ends at `last_child`.
+    /// - Every node claiming a parent appears in that parent's child
+    ///   chain.
+    /// - No cycles exist in sibling chains (bounded by arena length).
+    /// - The free list is well-formed: consistent first/last pointers,
+    ///   all entries are removed nodes with `NextFree` data, and no
+    ///   cycles.
+    ///
+    /// This is primarily useful after deserialization to detect
+    /// corrupted data.
     ///
     /// # Examples
     ///
@@ -627,6 +642,7 @@ impl<T> Arena<T> {
     /// root.append_value(2, &mut arena);
     /// assert!(arena.validate());
     /// ```
+    #[must_use]
     pub fn validate(&self) -> bool {
         let len = self.nodes.len();
 
@@ -640,6 +656,10 @@ impl<T> Arena<T> {
         for (i, node) in self.nodes.iter().enumerate() {
             if node.is_removed() {
                 continue;
+            }
+
+            if !matches!(node.data, NodeData::Data(_)) {
+                return false;
             }
 
             if let Some(parent) = node.parent {
@@ -860,6 +880,9 @@ impl<'a, T> IntoIterator for &'a mut Arena<T> {
 
 impl<T> Extend<T> for Arena<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        self.reserve(lower);
         for item in iter {
             self.new_node(item);
         }
@@ -914,6 +937,14 @@ impl<T> Index<NodeId> for Arena<T> {
     }
 }
 
+/// Mutable index by [`NodeId`].
+///
+/// Like [`Index<NodeId>`], this does **not** validate the node's stamp.
+/// For safe access, prefer [`Arena::get_mut`].
+///
+/// # Panics
+///
+/// Panics if `node` is out of bounds.
 impl<T> IndexMut<NodeId> for Arena<T> {
     #[inline]
     fn index_mut(&mut self, node: NodeId) -> &mut Node<T> {

--- a/indextree/src/id.rs
+++ b/indextree/src/id.rs
@@ -124,6 +124,7 @@ impl NodeId {
     }
 
     /// Creates a new `NodeId` from the given one-based index.
+    #[inline]
     pub(crate) fn from_non_zero_usize(index1: NonZeroUsize, stamp: NodeStamp) -> Self {
         NodeId { index1, stamp }
     }
@@ -770,6 +771,7 @@ impl NodeId {
     /// assert_eq!(root.descendant_count(&arena), 4);
     /// assert_eq!(a.descendant_count(&arena), 2);
     /// ```
+    #[must_use]
     pub fn descendant_count<T>(self, arena: &Arena<T>) -> usize {
         self.descendants(arena).count()
     }
@@ -913,6 +915,11 @@ impl NodeId {
     }
 
     /// Detaches a node from its parent and siblings. Children are not affected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node ID is out of bounds (e.g. after
+    /// [`Arena::clear`]).
     ///
     /// # Examples
     ///
@@ -1247,6 +1254,7 @@ impl NodeId {
         if self.ancestors(arena).any(|ancestor| new_child == ancestor) {
             return Err(NodeError::PrependAncestor);
         }
+        new_child.detach(arena);
         insert_with_neighbors(arena, new_child, Some(self), None, arena[self].first_child)
             .expect("Should never fail: `new_child` is not `self` and they are not removed");
 
@@ -1571,6 +1579,10 @@ impl NodeId {
     ///
     /// To check if the node is removed or not, use [`Node::is_removed()`](crate::Node::is_removed).
     ///
+    /// # Panics
+    ///
+    /// Panics if the node ID is out of bounds.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1681,6 +1693,11 @@ impl NodeId {
     }
 
     /// Removes a node and its descendants from the arena.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node ID is out of bounds.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1775,6 +1792,10 @@ impl NodeId {
     /// The children retain their own subtrees and sibling relationships
     /// with each other are removed.
     ///
+    /// # Panics
+    ///
+    /// Panics if the node ID is out of bounds.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1855,6 +1876,10 @@ impl NodeId {
     /// node itself in its current position.
     ///
     /// This is equivalent to calling [`remove_subtree`] on each child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the node ID is out of bounds.
     ///
     /// # Examples
     ///
@@ -2005,6 +2030,7 @@ impl NodeId {
     ///
     /// assert!(r1.subtree_eq(r2, &a1, &a2));
     /// ```
+    #[must_use]
     pub fn subtree_eq<T: PartialEq>(
         self,
         other: NodeId,

--- a/indextree/src/lib.rs
+++ b/indextree/src/lib.rs
@@ -17,7 +17,7 @@
 //!   [`Arena`], [`Node`], and [`NodeId`]. (The legacy name `deser` is
 //!   still accepted as an alias.)
 //! * `par_iter` - Enable parallel iteration via `Arena::par_iter()` using
-//!   [rayon](https://docs.rs/rayon).
+//!   [rayon](https://docs.rs/rayon). Requires `std`.
 //!
 //! # Node removal and reuse
 //!

--- a/indextree/src/node.rs
+++ b/indextree/src/node.rs
@@ -156,6 +156,7 @@ impl<T> Node<T> {
     }
 
     /// Creates a new `Node` with the default state and the given data.
+    #[inline]
     pub(crate) fn new(data: T) -> Self {
         Self {
             parent: None,
@@ -169,6 +170,7 @@ impl<T> Node<T> {
     }
 
     /// Convert a removed `Node` to normal with default state and given data.
+    #[inline]
     pub(crate) fn reuse(&mut self, data: T) {
         debug_assert!(matches!(self.data, NodeData::NextFree(_)));
         debug_assert!(self.stamp.is_removed());

--- a/indextree/src/traverse.rs
+++ b/indextree/src/traverse.rs
@@ -75,6 +75,7 @@ macro_rules! new_iterator {
         impl<'a, T> Iterator for $name<'a, T> {
             type Item = NodeId;
 
+            #[inline]
             fn next(&mut self) -> Option<NodeId> {
                 let next: fn(&Node<T>) -> Option<NodeId> = $next;
 
@@ -102,6 +103,7 @@ macro_rules! new_iterator {
         impl<'a, T> Iterator for $name<'a, T> {
             type Item = NodeId;
 
+            #[inline]
             fn next(&mut self) -> Option<NodeId> {
                 match (self.0.head, self.0.tail) {
                     (Some(head), Some(tail)) if head == tail => {
@@ -241,6 +243,7 @@ impl<'a, T> Descendants<'a, T> {
 impl<T> Iterator for Descendants<'_, T> {
     type Item = NodeId;
 
+    #[inline]
     fn next(&mut self) -> Option<NodeId> {
         let current = self.next.take()?;
         let node = &self.arena[current];
@@ -539,6 +542,7 @@ impl<'a, T> Traverse<'a, T> {
 impl<T> Iterator for Traverse<'_, T> {
     type Item = NodeEdge;
 
+    #[inline]
     fn next(&mut self) -> Option<NodeEdge> {
         let next = self.next.take()?;
         self.next = self.next_of_next(next);

--- a/indextree/tests/lib.rs
+++ b/indextree/tests/lib.rs
@@ -1556,3 +1556,103 @@ fn remove_children_deep_tree() {
         assert!(id.is_removed(&arena));
     }
 }
+
+#[test]
+fn checked_prepend_already_first_child() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let c1 = root.append_value("c1", &mut arena);
+    let c2 = root.append_value("c2", &mut arena);
+
+    // Prepending the existing first child should succeed (detach + re-insert).
+    assert!(root.checked_prepend(c1, &mut arena).is_ok());
+    let children: Vec<_> = root.children(&arena).collect();
+    assert_eq!(children, vec![c1, c2]);
+}
+
+#[test]
+fn checked_prepend_moves_child_from_another_parent() {
+    let mut arena = Arena::new();
+    let a = arena.new_node("a");
+    let b = arena.new_node("b");
+    let c = a.append_value("c", &mut arena);
+
+    // c is currently a child of a; prepending it to b should detach it first.
+    assert!(b.checked_prepend(c, &mut arena).is_ok());
+    assert_eq!(a.children(&arena).count(), 0);
+    assert_eq!(b.first_child(&arena), Some(c));
+}
+
+#[test]
+fn checked_detach_children_on_removed_node() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    root.append_value("child", &mut arena);
+    root.remove_subtree(&mut arena);
+
+    let result = root.checked_detach_children(&mut arena);
+    assert!(matches!(result, Err(NodeError::Removed)));
+}
+
+#[test]
+fn checked_remove_children_on_removed_node() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    root.append_value("child", &mut arena);
+    root.remove_subtree(&mut arena);
+
+    let result = root.checked_remove_children(&mut arena);
+    assert!(matches!(result, Err(NodeError::Removed)));
+}
+
+#[test]
+fn checked_reparent_to_self_returns_error() {
+    let mut arena = Arena::new();
+    let node = arena.new_node("node");
+
+    let result = node.checked_reparent(node, &mut arena);
+    assert!(matches!(result, Err(NodeError::AppendSelf)));
+}
+
+#[test]
+fn checked_reparent_to_descendant_returns_error() {
+    let mut arena = Arena::new();
+    let root = arena.new_node("root");
+    let child = root.append_value("child", &mut arena);
+
+    let result = root.checked_reparent(child, &mut arena);
+    assert!(matches!(result, Err(NodeError::AppendAncestor)));
+}
+
+#[test]
+fn into_data_on_freed_node() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(42);
+    root.remove_subtree(&mut arena);
+
+    let result = arena.into_iter().next().unwrap().into_data();
+    assert!(result.is_none());
+}
+
+#[test]
+fn map_preserves_removed_nodes() {
+    let mut arena = Arena::new();
+    let root = arena.new_node(1);
+    root.append_value(2, &mut arena);
+    let c = root.append_value(3, &mut arena);
+    c.remove_subtree(&mut arena);
+
+    let mapped = arena.map(|val| val * 10);
+    assert!(mapped.validate());
+
+    let root2 = mapped.iter().next().unwrap();
+    assert_eq!(*root2.get(), 10);
+}
+
+#[test]
+fn extend_reserves_capacity() {
+    let mut arena: Arena<i32> = Arena::new();
+    arena.extend(0..100);
+    assert!(arena.capacity() >= 100);
+    assert_eq!(arena.len(), 100);
+}

--- a/indextree/tests/serde.rs
+++ b/indextree/tests/serde.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "serde")]
 
 use indextree::Arena;
+use serde_json::json;
 
 #[test]
 fn round_trip_empty_arena() {
@@ -66,4 +67,166 @@ fn round_trip_with_reused_slot() {
     let deserialized: Arena<i32> = serde_json::from_str(&json).unwrap();
     assert_eq!(arena, deserialized);
     assert!(deserialized.validate());
+}
+
+#[test]
+fn validate_rejects_broken_parent_pointer() {
+    let val = json!({
+        "nodes": [
+            {
+                "parent": null,
+                "previous_sibling": null,
+                "next_sibling": null,
+                "first_child": {"index1": 2, "stamp": 0},
+                "last_child": {"index1": 2, "stamp": 0},
+                "stamp": 0,
+                "data": {"Data": 1}
+            },
+            {
+                "parent": null,
+                "previous_sibling": null,
+                "next_sibling": null,
+                "first_child": null,
+                "last_child": null,
+                "stamp": 0,
+                "data": {"Data": 2}
+            }
+        ],
+        "first_free_slot": null,
+        "last_free_slot": null
+    });
+    let arena: Arena<i32> = serde_json::from_value(val).unwrap();
+    assert!(!arena.validate());
+}
+
+#[test]
+fn validate_rejects_live_node_with_next_free_data() {
+    let val = json!({
+        "nodes": [
+            {
+                "parent": null,
+                "previous_sibling": null,
+                "next_sibling": null,
+                "first_child": null,
+                "last_child": null,
+                "stamp": 0,
+                "data": {"NextFree": null}
+            }
+        ],
+        "first_free_slot": null,
+        "last_free_slot": null
+    });
+    let arena: Arena<i32> = serde_json::from_value(val).unwrap();
+    assert!(!arena.validate());
+}
+
+#[test]
+fn validate_rejects_broken_sibling_chain() {
+    let val = json!({
+        "nodes": [
+            {
+                "parent": null,
+                "previous_sibling": null,
+                "next_sibling": null,
+                "first_child": {"index1": 2, "stamp": 0},
+                "last_child": {"index1": 3, "stamp": 0},
+                "stamp": 0,
+                "data": {"Data": 1}
+            },
+            {
+                "parent": {"index1": 1, "stamp": 0},
+                "previous_sibling": null,
+                "next_sibling": {"index1": 3, "stamp": 0},
+                "first_child": null,
+                "last_child": null,
+                "stamp": 0,
+                "data": {"Data": 2}
+            },
+            {
+                "parent": {"index1": 1, "stamp": 0},
+                "previous_sibling": null,
+                "next_sibling": null,
+                "first_child": null,
+                "last_child": null,
+                "stamp": 0,
+                "data": {"Data": 3}
+            }
+        ],
+        "first_free_slot": null,
+        "last_free_slot": null
+    });
+    let arena: Arena<i32> = serde_json::from_value(val).unwrap();
+    assert!(!arena.validate());
+}
+
+#[test]
+fn validate_rejects_mismatched_free_list_pointers() {
+    let val = json!({
+        "nodes": [
+            {
+                "parent": null,
+                "previous_sibling": null,
+                "next_sibling": null,
+                "first_child": null,
+                "last_child": null,
+                "stamp": 0,
+                "data": {"Data": 1}
+            }
+        ],
+        "first_free_slot": 0,
+        "last_free_slot": null
+    });
+    let arena: Arena<i32> = serde_json::from_value(val).unwrap();
+    assert!(!arena.validate());
+}
+
+#[test]
+fn validate_rejects_stale_stamp_in_child_pointer() {
+    let val = json!({
+        "nodes": [
+            {
+                "parent": null,
+                "previous_sibling": null,
+                "next_sibling": null,
+                "first_child": {"index1": 2, "stamp": 99},
+                "last_child": {"index1": 2, "stamp": 99},
+                "stamp": 0,
+                "data": {"Data": 1}
+            },
+            {
+                "parent": {"index1": 1, "stamp": 0},
+                "previous_sibling": null,
+                "next_sibling": null,
+                "first_child": null,
+                "last_child": null,
+                "stamp": 0,
+                "data": {"Data": 2}
+            }
+        ],
+        "first_free_slot": null,
+        "last_free_slot": null
+    });
+    let arena: Arena<i32> = serde_json::from_value(val).unwrap();
+    assert!(!arena.validate());
+}
+
+#[test]
+fn validate_rejects_out_of_bounds_pointer() {
+    let val = json!({
+        "nodes": [
+            {
+                "parent": null,
+                "previous_sibling": null,
+                "next_sibling": null,
+                "first_child": {"index1": 99, "stamp": 0},
+                "last_child": {"index1": 99, "stamp": 0},
+                "stamp": 0,
+                "data": {"Data": 1}
+            }
+        ],
+        "first_free_slot": null,
+        "last_free_slot": null
+    });
+    let arena: Arena<i32> = serde_json::from_value(val).unwrap();
+    assert!(!arena.validate());
 }


### PR DESCRIPTION
- Fix `checked_prepend` missing `detach` call that caused panics when prepending an already-attached node
- Harden `validate()` to reject live nodes with `NextFree` data and expand its doc comment
- Add `#[must_use]` to `validate`, `descendant_count`, `subtree_eq`
- Add `#[inline]` to hot-path internal functions and iterator `next()` methods
- Pre-reserve capacity in `Extend` impl using `size_hint`
- Document `par_iter` feature requires `std`
- Add `# Panics` sections to `detach`, `remove`, `remove_subtree`, `detach_children`, `remove_children`
- Add doc comment to `IndexMut<NodeId>` impl noting stamp bypass
- Add regression tests for `checked_prepend`, error path coverage, `map` with removed nodes, `into_data` on freed nodes, and `extend` capacity reservation
- Add adversarial serde tests: broken parent pointers, stale stamps, broken sibling chains, mismatched free list, out-of-bounds pointers, live nodes with `NextFree` data
- Add `cargo-deny` CI job with `deny.toml` config
- Add caching for `no-std-target` CI job